### PR TITLE
refactor: Template Methodパターンで視覚ルールの重複コードを削減

### DIFF
--- a/src/visual/base-visual-rule.ts
+++ b/src/visual/base-visual-rule.ts
@@ -1,0 +1,196 @@
+/**
+ * Base class for visual rules using Template Method pattern
+ * Eliminates code duplication across visual rule checkers
+ */
+
+import { chromium, type Browser, type Page } from 'playwright';
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import type { LintError } from '../rules/slide-line-count.js';
+
+export interface BaseVisualConfig {
+  enabled?: boolean;
+  viewport?: {
+    width?: number;
+    height?: number;
+  };
+}
+
+export interface VisualCheckResult<TResult> {
+  errors: LintError[];
+  results: TResult[];
+}
+
+const DEFAULT_VIEWPORT = {
+  width: 1280,
+  height: 720
+};
+
+/**
+ * Detect installed Chromium-based browser
+ */
+export function detectInstalledBrowser(): string | null {
+  const browserPaths = [
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/opt/google/chrome/chrome',
+    '/usr/bin/microsoft-edge',
+    '/usr/bin/microsoft-edge-stable',
+    '/snap/bin/chromium',
+  ];
+
+  for (const browserPath of browserPaths) {
+    if (existsSync(browserPath)) {
+      return browserPath;
+    }
+  }
+
+  const commands = ['google-chrome', 'chromium', 'chromium-browser', 'microsoft-edge'];
+  for (const cmd of commands) {
+    try {
+      const result = execSync(`which ${cmd}`, { encoding: 'utf-8' }).trim();
+      if (result) return result;
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build Marp HTML from markdown file
+ */
+export async function buildMarpHtml(markdownPath: string, tmpPrefix: string): Promise<{ htmlContent: string; tmpDir: string }> {
+  const tmpDir = await fs.mkdtemp(join(tmpdir(), `marplint-${tmpPrefix}-`));
+  const tmpHtmlPath = join(tmpDir, 'output.html');
+
+  const absolutePath = resolve(markdownPath);
+  execSync(
+    `bunx --bun @marp-team/marp-cli@latest --no-stdin --html --allow-local-files "${absolutePath}" -o "${tmpHtmlPath}"`,
+    { stdio: 'pipe', encoding: 'utf-8' }
+  );
+
+  const htmlContent = await fs.readFile(tmpHtmlPath, 'utf-8');
+  return { htmlContent, tmpDir };
+}
+
+/**
+ * Launch browser with detected or bundled Chromium
+ */
+export async function launchBrowser(): Promise<Browser> {
+  const browserPath = detectInstalledBrowser();
+  const launchOptions: { headless: boolean; executablePath?: string } = { headless: true };
+  if (browserPath) {
+    launchOptions.executablePath = browserPath;
+  }
+  return chromium.launch(launchOptions);
+}
+
+/**
+ * Setup page with viewport and content
+ */
+export async function setupPage(
+  browser: Browser,
+  htmlContent: string,
+  viewport: { width: number; height: number }
+): Promise<Page> {
+  const page = await browser.newPage();
+  await page.setViewportSize(viewport);
+  await page.setContent(htmlContent, { waitUntil: 'networkidle' });
+  return page;
+}
+
+/**
+ * Cleanup temporary directory
+ */
+export async function cleanupTmpDir(tmpDir: string): Promise<void> {
+  try {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+/**
+ * Get merged viewport configuration
+ */
+export function getMergedViewport(config?: { width?: number; height?: number }): { width: number; height: number } {
+  return {
+    width: config?.width ?? DEFAULT_VIEWPORT.width,
+    height: config?.height ?? DEFAULT_VIEWPORT.height
+  };
+}
+
+/**
+ * Abstract base class for visual rules using Template Method pattern
+ */
+export abstract class BaseVisualRule<TConfig extends BaseVisualConfig, TResult> {
+  protected abstract readonly tmpPrefix: string;
+  protected abstract readonly defaultConfig: Required<TConfig>;
+
+  /**
+   * Template method: orchestrates the visual check process
+   */
+  async check(
+    markdownPath: string,
+    config: TConfig = {} as TConfig
+  ): Promise<VisualCheckResult<TResult>> {
+    const mergedConfig = this.mergeConfig(config);
+
+    if (!mergedConfig.enabled) {
+      return { errors: [], results: [] };
+    }
+
+    const { htmlContent, tmpDir } = await buildMarpHtml(markdownPath, this.tmpPrefix);
+
+    try {
+      const browser = await launchBrowser();
+
+      try {
+        const viewport = getMergedViewport(mergedConfig.viewport);
+        const page = await setupPage(browser, htmlContent, viewport);
+
+        const results = await this.analyze(page, mergedConfig);
+        const errors = this.convertToErrors(results, mergedConfig);
+
+        return { errors, results };
+      } finally {
+        await browser.close();
+      }
+    } finally {
+      await cleanupTmpDir(tmpDir);
+    }
+  }
+
+  /**
+   * Hook: merge user config with defaults
+   */
+  protected mergeConfig(config: TConfig): Required<TConfig> {
+    return {
+      ...this.defaultConfig,
+      ...config,
+      viewport: {
+        ...this.defaultConfig.viewport,
+        ...config.viewport
+      }
+    } as Required<TConfig>;
+  }
+
+  /**
+   * Abstract method: perform the actual visual analysis
+   * Subclasses must implement this with their specific logic
+   */
+  protected abstract analyze(page: Page, config: Required<TConfig>): Promise<TResult[]>;
+
+  /**
+   * Abstract method: convert analysis results to lint errors
+   * Subclasses must implement this with their specific error creation logic
+   */
+  protected abstract convertToErrors(results: TResult[], config: Required<TConfig>): LintError[];
+}

--- a/src/visual/color-contrast.ts
+++ b/src/visual/color-contrast.ts
@@ -3,21 +3,13 @@
  * Checks color contrast ratio for WCAG compliance
  */
 
-import { chromium } from 'playwright';
-import { execSync } from 'child_process';
-import { promises as fs } from 'fs';
-import { tmpdir } from 'os';
-import { join, resolve } from 'path';
+import type { Page } from 'playwright';
+import { BaseVisualRule, type BaseVisualConfig } from './base-visual-rule.js';
 import type { LintError } from '../rules/slide-line-count.js';
 
-export interface ColorContrastConfig {
-  enabled?: boolean;
+export interface ColorContrastConfig extends BaseVisualConfig {
   minContrastRatio?: number; // WCAG AA requires 4.5:1 for normal text
   minContrastRatioLarge?: number; // WCAG AA requires 3:1 for large text (18px+)
-  viewport?: {
-    width?: number;
-    height?: number;
-  };
 }
 
 export interface ColorContrastResult {
@@ -41,172 +33,123 @@ const DEFAULT_CONFIG: Required<ColorContrastConfig> = {
   }
 };
 
-function detectInstalledBrowser(): string | null {
-  const browserPaths = [
-    '/usr/bin/google-chrome',
-    '/usr/bin/google-chrome-stable',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser',
-    '/snap/bin/chromium',
-  ];
+class ColorContrastRule extends BaseVisualRule<ColorContrastConfig, ColorContrastResult> {
+  protected readonly tmpPrefix = 'contrast';
+  protected readonly defaultConfig = DEFAULT_CONFIG;
 
-  const existsSync = require('fs').existsSync;
-  for (const browserPath of browserPaths) {
-    if (existsSync(browserPath)) {
-      return browserPath;
-    }
+  protected async analyze(page: Page, config: Required<ColorContrastConfig>): Promise<ColorContrastResult[]> {
+    return await page.evaluate((cfg: { minRatio: number; minRatioLarge: number }) => {
+      // Helper functions for color contrast calculation
+      function parseColor(colorStr: string): { r: number; g: number; b: number; a: number } | null {
+        const rgbMatch = colorStr.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
+        if (rgbMatch) {
+          return {
+            r: parseInt(rgbMatch[1] ?? '0'),
+            g: parseInt(rgbMatch[2] ?? '0'),
+            b: parseInt(rgbMatch[3] ?? '0'),
+            a: parseFloat(rgbMatch[4] ?? '1')
+          };
+        }
+        return null;
+      }
+
+      function getLuminance(r: number, g: number, b: number): number {
+        const [rs, gs, bs] = [r, g, b].map(c => {
+          c = c / 255;
+          return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+        });
+        return 0.2126 * (rs ?? 0) + 0.7152 * (gs ?? 0) + 0.0722 * (bs ?? 0);
+      }
+
+      function getContrastRatio(l1: number, l2: number): number {
+        const lighter = Math.max(l1, l2);
+        const darker = Math.min(l1, l2);
+        return (lighter + 0.05) / (darker + 0.05);
+      }
+
+      const sections = Array.from(document.querySelectorAll('section'));
+
+      return sections.map((section, index) => {
+        const lowContrastElements: Array<{
+          text: string;
+          foreground: string;
+          background: string;
+          ratio: number;
+          fontSize: number;
+        }> = [];
+
+        const textElements = section.querySelectorAll('p, li, h1, h2, h3, h4, h5, h6, span, td, th');
+
+        textElements.forEach((el) => {
+          const style = window.getComputedStyle(el);
+          const text = (el as HTMLElement).innerText?.trim().substring(0, 30) || '';
+          if (!text) return;
+
+          const foreground = style.color;
+          const background = style.backgroundColor;
+          const fontSize = parseFloat(style.fontSize);
+
+          const fgColor = parseColor(foreground);
+          const bgColor = parseColor(background);
+
+          if (fgColor && bgColor && bgColor.a > 0) {
+            const fgLum = getLuminance(fgColor.r, fgColor.g, fgColor.b);
+            const bgLum = getLuminance(bgColor.r, bgColor.g, bgColor.b);
+            const ratio = getContrastRatio(fgLum, bgLum);
+
+            const requiredRatio = fontSize >= 18 ? cfg.minRatioLarge : cfg.minRatio;
+
+            if (ratio < requiredRatio) {
+              lowContrastElements.push({
+                text,
+                foreground,
+                background,
+                ratio: Math.round(ratio * 100) / 100,
+                fontSize: Math.round(fontSize)
+              });
+            }
+          }
+        });
+
+        return {
+          slideNumber: index + 1,
+          lowContrastElements: lowContrastElements.slice(0, 3)
+        };
+      });
+    }, { minRatio: config.minContrastRatio, minRatioLarge: config.minContrastRatioLarge }) as ColorContrastResult[];
   }
-  return null;
+
+  protected convertToErrors(results: ColorContrastResult[]): LintError[] {
+    const errors: LintError[] = [];
+
+    for (const result of results) {
+      if (result.lowContrastElements.length > 0) {
+        const element = result.lowContrastElements[0];
+        if (element) {
+          errors.push({
+            ruleId: 'marp/color-contrast',
+            slideNumber: result.slideNumber,
+            lineNumber: 0,
+            message: `Slide ${result.slideNumber}: Low color contrast (${element.ratio}:1). WCAG AA requires at least 4.5:1 for normal text.`,
+            severity: 'warning'
+          });
+        }
+      }
+    }
+
+    return errors;
+  }
 }
 
+// Singleton instance
+const colorContrastChecker = new ColorContrastRule();
+
+/**
+ * Check color contrast in slides
+ */
 export async function checkColorContrast(
   markdownPath: string,
   config: ColorContrastConfig = {}
 ): Promise<{ errors: LintError[]; results: ColorContrastResult[] }> {
-  const mergedConfig = {
-    ...DEFAULT_CONFIG,
-    viewport: { ...DEFAULT_CONFIG.viewport, ...config.viewport }
-  };
-
-  if (!mergedConfig.enabled) {
-    return { errors: [], results: [] };
-  }
-
-  const tmpDir = await fs.mkdtemp(join(tmpdir(), 'marplint-contrast-'));
-  const tmpHtmlPath = join(tmpDir, 'output.html');
-
-  try {
-    const absolutePath = resolve(markdownPath);
-    execSync(
-      `bunx --bun @marp-team/marp-cli@latest --no-stdin --html --allow-local-files "${absolutePath}" -o "${tmpHtmlPath}"`,
-      { stdio: 'pipe', encoding: 'utf-8' }
-    );
-
-    const htmlContent = await fs.readFile(tmpHtmlPath, 'utf-8');
-
-    const browserPath = detectInstalledBrowser();
-    const launchOptions: { headless: boolean; executablePath?: string } = { headless: true };
-    if (browserPath) {
-      launchOptions.executablePath = browserPath;
-    }
-
-    const browser = await chromium.launch(launchOptions);
-
-    try {
-      const page = await browser.newPage();
-      await page.setViewportSize({
-        width: mergedConfig.viewport.width,
-        height: mergedConfig.viewport.height
-      });
-
-      await page.setContent(htmlContent, { waitUntil: 'networkidle' });
-
-      const results = await page.evaluate((config: { minRatio: number; minRatioLarge: number }) => {
-        // Helper functions for color contrast calculation
-        function parseColor(colorStr: string): { r: number; g: number; b: number; a: number } | null {
-          // Handle rgb/rgba
-          const rgbMatch = colorStr.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
-          if (rgbMatch) {
-            return {
-              r: parseInt(rgbMatch[1] ?? '0'),
-              g: parseInt(rgbMatch[2] ?? '0'),
-              b: parseInt(rgbMatch[3] ?? '0'),
-              a: parseFloat(rgbMatch[4] ?? '1')
-            };
-          }
-          return null;
-        }
-
-        function getLuminance(r: number, g: number, b: number): number {
-          const [rs, gs, bs] = [r, g, b].map(c => {
-            c = c / 255;
-            return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-          });
-          return 0.2126 * (rs ?? 0) + 0.7152 * (gs ?? 0) + 0.0722 * (bs ?? 0);
-        }
-
-        function getContrastRatio(l1: number, l2: number): number {
-          const lighter = Math.max(l1, l2);
-          const darker = Math.min(l1, l2);
-          return (lighter + 0.05) / (darker + 0.05);
-        }
-
-        const sections = Array.from(document.querySelectorAll('section'));
-
-        return sections.map((section, index) => {
-          const lowContrastElements: Array<{
-            text: string;
-            foreground: string;
-            background: string;
-            ratio: number;
-            fontSize: number;
-          }> = [];
-
-          const textElements = section.querySelectorAll('p, li, h1, h2, h3, h4, h5, h6, span, td, th');
-
-          textElements.forEach((el) => {
-            const style = window.getComputedStyle(el);
-            const text = (el as HTMLElement).innerText?.trim().substring(0, 30) || '';
-            if (!text) return;
-
-            const foreground = style.color;
-            const background = style.backgroundColor;
-            const fontSize = parseFloat(style.fontSize);
-
-            const fgColor = parseColor(foreground);
-            const bgColor = parseColor(background);
-
-            if (fgColor && bgColor && bgColor.a > 0) {
-              const fgLum = getLuminance(fgColor.r, fgColor.g, fgColor.b);
-              const bgLum = getLuminance(bgColor.r, bgColor.g, bgColor.b);
-              const ratio = getContrastRatio(fgLum, bgLum);
-
-              const requiredRatio = fontSize >= 18 ? config.minRatioLarge : config.minRatio;
-
-              if (ratio < requiredRatio) {
-                lowContrastElements.push({
-                  text,
-                  foreground,
-                  background,
-                  ratio: Math.round(ratio * 100) / 100,
-                  fontSize: Math.round(fontSize)
-                });
-              }
-            }
-          });
-
-          return {
-            slideNumber: index + 1,
-            lowContrastElements: lowContrastElements.slice(0, 3)
-          };
-        });
-      }, { minRatio: mergedConfig.minContrastRatio, minRatioLarge: mergedConfig.minContrastRatioLarge }) as ColorContrastResult[];
-
-      const errors: LintError[] = [];
-      for (const result of results) {
-        if (result.lowContrastElements.length > 0) {
-          const element = result.lowContrastElements[0];
-          if (element) {
-            errors.push({
-              ruleId: 'marp/color-contrast',
-              slideNumber: result.slideNumber,
-              lineNumber: 0,
-              message: `Slide ${result.slideNumber}: Low color contrast (${element.ratio}:1). WCAG AA requires at least 4.5:1 for normal text.`,
-              severity: 'warning'
-            });
-          }
-        }
-      }
-
-      return { errors, results };
-
-    } finally {
-      await browser.close();
-    }
-
-  } finally {
-    try {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    } catch { /* ignore */ }
-  }
+  return colorContrastChecker.check(markdownPath, config);
 }

--- a/src/visual/element-overlap.ts
+++ b/src/visual/element-overlap.ts
@@ -3,20 +3,12 @@
  * Detects overlapping elements in slides
  */
 
-import { chromium } from 'playwright';
-import { execSync } from 'child_process';
-import { promises as fs } from 'fs';
-import { tmpdir } from 'os';
-import { join, resolve } from 'path';
+import type { Page } from 'playwright';
+import { BaseVisualRule, type BaseVisualConfig } from './base-visual-rule.js';
 import type { LintError } from '../rules/slide-line-count.js';
 
-export interface ElementOverlapConfig {
-  enabled?: boolean;
+export interface ElementOverlapConfig extends BaseVisualConfig {
   minOverlapArea?: number; // Minimum overlap area in pixels to report
-  viewport?: {
-    width?: number;
-    height?: number;
-  };
 }
 
 export interface ElementOverlapResult {
@@ -37,155 +29,107 @@ const DEFAULT_CONFIG: Required<ElementOverlapConfig> = {
   }
 };
 
-function detectInstalledBrowser(): string | null {
-  const browserPaths = [
-    '/usr/bin/google-chrome',
-    '/usr/bin/google-chrome-stable',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser',
-    '/snap/bin/chromium',
-  ];
+class ElementOverlapRule extends BaseVisualRule<ElementOverlapConfig, ElementOverlapResult> {
+  protected readonly tmpPrefix = 'overlap';
+  protected readonly defaultConfig = DEFAULT_CONFIG;
 
-  const existsSync = require('fs').existsSync;
-  for (const browserPath of browserPaths) {
-    if (existsSync(browserPath)) {
-      return browserPath;
-    }
+  protected async analyze(page: Page, config: Required<ElementOverlapConfig>): Promise<ElementOverlapResult[]> {
+    return await page.evaluate((minArea: number) => {
+      function getOverlapArea(rect1: DOMRect, rect2: DOMRect): number {
+        const xOverlap = Math.max(0, Math.min(rect1.right, rect2.right) - Math.max(rect1.left, rect2.left));
+        const yOverlap = Math.max(0, Math.min(rect1.bottom, rect2.bottom) - Math.max(rect1.top, rect2.top));
+        return xOverlap * yOverlap;
+      }
+
+      function getElementDescription(el: Element): string {
+        const tag = el.tagName.toLowerCase();
+        const text = (el as HTMLElement).innerText?.trim().substring(0, 20) || '';
+        return text ? `${tag}: "${text}..."` : tag;
+      }
+
+      const sections = Array.from(document.querySelectorAll('section'));
+
+      return sections.map((section, index) => {
+        const overlaps: Array<{
+          element1: string;
+          element2: string;
+          overlapArea: number;
+        }> = [];
+
+        // Get all positioned or block elements
+        const elements = Array.from(section.querySelectorAll('h1, h2, h3, h4, h5, h6, p, ul, ol, table, div, img, figure'));
+        const rects: Array<{ element: Element; rect: DOMRect }> = [];
+
+        elements.forEach((el) => {
+          const rect = el.getBoundingClientRect();
+          // Only consider elements with actual size
+          if (rect.width > 10 && rect.height > 10) {
+            rects.push({ element: el, rect });
+          }
+        });
+
+        // Check for overlaps
+        for (let i = 0; i < rects.length; i++) {
+          for (let j = i + 1; j < rects.length; j++) {
+            const r1 = rects[i];
+            const r2 = rects[j];
+            if (!r1 || !r2) continue;
+
+            // Skip if one is ancestor of another
+            if (r1.element.contains(r2.element) || r2.element.contains(r1.element)) {
+              continue;
+            }
+
+            const overlapArea = getOverlapArea(r1.rect, r2.rect);
+            if (overlapArea >= minArea) {
+              overlaps.push({
+                element1: getElementDescription(r1.element),
+                element2: getElementDescription(r2.element),
+                overlapArea: Math.round(overlapArea)
+              });
+            }
+          }
+        }
+
+        return {
+          slideNumber: index + 1,
+          overlaps: overlaps.slice(0, 3) // Limit to first 3
+        };
+      });
+    }, config.minOverlapArea) as ElementOverlapResult[];
   }
-  return null;
+
+  protected convertToErrors(results: ElementOverlapResult[]): LintError[] {
+    const errors: LintError[] = [];
+
+    for (const result of results) {
+      if (result.overlaps.length > 0) {
+        const overlap = result.overlaps[0];
+        if (overlap) {
+          errors.push({
+            ruleId: 'marp/element-overlap',
+            slideNumber: result.slideNumber,
+            lineNumber: 0,
+            message: `Slide ${result.slideNumber}: Elements are overlapping (${overlap.overlapArea}px²). "${overlap.element1}" overlaps with "${overlap.element2}".`,
+            severity: 'error'
+          });
+        }
+      }
+    }
+
+    return errors;
+  }
 }
 
+// Singleton instance
+const elementOverlapChecker = new ElementOverlapRule();
+
+/**
+ * Check for element overlaps in slides
+ */
 export async function checkElementOverlap(
   markdownPath: string,
   config: ElementOverlapConfig = {}
 ): Promise<{ errors: LintError[]; results: ElementOverlapResult[] }> {
-  const mergedConfig = {
-    ...DEFAULT_CONFIG,
-    viewport: { ...DEFAULT_CONFIG.viewport, ...config.viewport }
-  };
-
-  if (!mergedConfig.enabled) {
-    return { errors: [], results: [] };
-  }
-
-  const tmpDir = await fs.mkdtemp(join(tmpdir(), 'marplint-overlap-'));
-  const tmpHtmlPath = join(tmpDir, 'output.html');
-
-  try {
-    const absolutePath = resolve(markdownPath);
-    execSync(
-      `bunx --bun @marp-team/marp-cli@latest --no-stdin --html --allow-local-files "${absolutePath}" -o "${tmpHtmlPath}"`,
-      { stdio: 'pipe', encoding: 'utf-8' }
-    );
-
-    const htmlContent = await fs.readFile(tmpHtmlPath, 'utf-8');
-
-    const browserPath = detectInstalledBrowser();
-    const launchOptions: { headless: boolean; executablePath?: string } = { headless: true };
-    if (browserPath) {
-      launchOptions.executablePath = browserPath;
-    }
-
-    const browser = await chromium.launch(launchOptions);
-
-    try {
-      const page = await browser.newPage();
-      await page.setViewportSize({
-        width: mergedConfig.viewport.width,
-        height: mergedConfig.viewport.height
-      });
-
-      await page.setContent(htmlContent, { waitUntil: 'networkidle' });
-
-      const results = await page.evaluate((minArea: number) => {
-        function getOverlapArea(rect1: DOMRect, rect2: DOMRect): number {
-          const xOverlap = Math.max(0, Math.min(rect1.right, rect2.right) - Math.max(rect1.left, rect2.left));
-          const yOverlap = Math.max(0, Math.min(rect1.bottom, rect2.bottom) - Math.max(rect1.top, rect2.top));
-          return xOverlap * yOverlap;
-        }
-
-        function getElementDescription(el: Element): string {
-          const tag = el.tagName.toLowerCase();
-          const text = (el as HTMLElement).innerText?.trim().substring(0, 20) || '';
-          return text ? `${tag}: "${text}..."` : tag;
-        }
-
-        const sections = Array.from(document.querySelectorAll('section'));
-
-        return sections.map((section, index) => {
-          const overlaps: Array<{
-            element1: string;
-            element2: string;
-            overlapArea: number;
-          }> = [];
-
-          // Get all positioned or block elements
-          const elements = Array.from(section.querySelectorAll('h1, h2, h3, h4, h5, h6, p, ul, ol, table, div, img, figure'));
-          const rects: Array<{ element: Element; rect: DOMRect }> = [];
-
-          elements.forEach((el) => {
-            const rect = el.getBoundingClientRect();
-            // Only consider elements with actual size
-            if (rect.width > 10 && rect.height > 10) {
-              rects.push({ element: el, rect });
-            }
-          });
-
-          // Check for overlaps
-          for (let i = 0; i < rects.length; i++) {
-            for (let j = i + 1; j < rects.length; j++) {
-              const r1 = rects[i];
-              const r2 = rects[j];
-              if (!r1 || !r2) continue;
-
-              // Skip if one is ancestor of another
-              if (r1.element.contains(r2.element) || r2.element.contains(r1.element)) {
-                continue;
-              }
-
-              const overlapArea = getOverlapArea(r1.rect, r2.rect);
-              if (overlapArea >= minArea) {
-                overlaps.push({
-                  element1: getElementDescription(r1.element),
-                  element2: getElementDescription(r2.element),
-                  overlapArea: Math.round(overlapArea)
-                });
-              }
-            }
-          }
-
-          return {
-            slideNumber: index + 1,
-            overlaps: overlaps.slice(0, 3) // Limit to first 3
-          };
-        });
-      }, mergedConfig.minOverlapArea) as ElementOverlapResult[];
-
-      const errors: LintError[] = [];
-      for (const result of results) {
-        if (result.overlaps.length > 0) {
-          const overlap = result.overlaps[0];
-          if (overlap) {
-            errors.push({
-              ruleId: 'marp/element-overlap',
-              slideNumber: result.slideNumber,
-              lineNumber: 0,
-              message: `Slide ${result.slideNumber}: Elements are overlapping (${overlap.overlapArea}px²). "${overlap.element1}" overlaps with "${overlap.element2}".`,
-              severity: 'error'
-            });
-          }
-        }
-      }
-
-      return { errors, results };
-
-    } finally {
-      await browser.close();
-    }
-
-  } finally {
-    try {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    } catch { /* ignore */ }
-  }
+  return elementOverlapChecker.check(markdownPath, config);
 }

--- a/src/visual/font-readability.ts
+++ b/src/visual/font-readability.ts
@@ -3,21 +3,13 @@
  * Checks if font sizes are readable (minimum size thresholds)
  */
 
-import { chromium } from 'playwright';
-import { execSync } from 'child_process';
-import { promises as fs } from 'fs';
-import { tmpdir } from 'os';
-import { join, resolve } from 'path';
+import type { Page } from 'playwright';
+import { BaseVisualRule, type BaseVisualConfig } from './base-visual-rule.js';
 import type { LintError } from '../rules/slide-line-count.js';
 
-export interface FontReadabilityConfig {
-  enabled?: boolean;
+export interface FontReadabilityConfig extends BaseVisualConfig {
   minFontSize?: number; // Minimum font size in pixels
   warnFontSize?: number; // Warn if font is smaller than this
-  viewport?: {
-    width?: number;
-    height?: number;
-  };
 }
 
 export interface FontReadabilityResult {
@@ -41,132 +33,84 @@ const DEFAULT_CONFIG: Required<FontReadabilityConfig> = {
   }
 };
 
-function detectInstalledBrowser(): string | null {
-  const browserPaths = [
-    '/usr/bin/google-chrome',
-    '/usr/bin/google-chrome-stable',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser',
-    '/snap/bin/chromium',
-  ];
+class FontReadabilityRule extends BaseVisualRule<FontReadabilityConfig, FontReadabilityResult> {
+  protected readonly tmpPrefix = 'font';
+  protected readonly defaultConfig = DEFAULT_CONFIG;
 
-  const existsSync = require('fs').existsSync;
-  for (const browserPath of browserPaths) {
-    if (existsSync(browserPath)) {
-      return browserPath;
-    }
+  protected async analyze(page: Page, config: Required<FontReadabilityConfig>): Promise<FontReadabilityResult[]> {
+    return await page.evaluate((warnSize: number) => {
+      const sections = Array.from(document.querySelectorAll('section'));
+
+      return sections.map((section, index) => {
+        const textElements = section.querySelectorAll('*');
+        const fontSizes: number[] = [];
+        const smallElements: Array<{ text: string; fontSize: number }> = [];
+
+        textElements.forEach((el) => {
+          const style = window.getComputedStyle(el);
+          const fontSize = parseFloat(style.fontSize);
+          const text = (el as HTMLElement).innerText?.trim().substring(0, 30) || '';
+
+          if (text && fontSize > 0) {
+            fontSizes.push(fontSize);
+            if (fontSize < warnSize) {
+              smallElements.push({ text, fontSize: Math.round(fontSize) });
+            }
+          }
+        });
+
+        const minFontSize = fontSizes.length > 0 ? Math.min(...fontSizes) : 0;
+        const avgFontSize = fontSizes.length > 0
+          ? fontSizes.reduce((a, b) => a + b, 0) / fontSizes.length
+          : 0;
+
+        return {
+          slideNumber: index + 1,
+          minFontSize: Math.round(minFontSize),
+          avgFontSize: Math.round(avgFontSize),
+          smallTextCount: smallElements.length,
+          elements: smallElements.slice(0, 3) // Limit to first 3
+        };
+      });
+    }, config.warnFontSize) as FontReadabilityResult[];
   }
-  return null;
+
+  protected convertToErrors(results: FontReadabilityResult[], config: Required<FontReadabilityConfig>): LintError[] {
+    const errors: LintError[] = [];
+
+    for (const result of results) {
+      if (result.minFontSize > 0 && result.minFontSize < config.minFontSize) {
+        errors.push({
+          ruleId: 'marp/font-readability',
+          slideNumber: result.slideNumber,
+          lineNumber: 0,
+          message: `Slide ${result.slideNumber}: Font size ${result.minFontSize}px is below minimum (${config.minFontSize}px). Text may be unreadable.`,
+          severity: 'error'
+        });
+      } else if (result.minFontSize > 0 && result.minFontSize < config.warnFontSize) {
+        errors.push({
+          ruleId: 'marp/font-readability',
+          slideNumber: result.slideNumber,
+          lineNumber: 0,
+          message: `Slide ${result.slideNumber}: Small font detected (${result.minFontSize}px). Consider using larger text for better readability.`,
+          severity: 'warning'
+        });
+      }
+    }
+
+    return errors;
+  }
 }
 
+// Singleton instance
+const fontReadabilityChecker = new FontReadabilityRule();
+
+/**
+ * Check font readability in slides
+ */
 export async function checkFontReadability(
   markdownPath: string,
   config: FontReadabilityConfig = {}
 ): Promise<{ errors: LintError[]; results: FontReadabilityResult[] }> {
-  const mergedConfig = {
-    ...DEFAULT_CONFIG,
-    viewport: { ...DEFAULT_CONFIG.viewport, ...config.viewport }
-  };
-
-  if (!mergedConfig.enabled) {
-    return { errors: [], results: [] };
-  }
-
-  const tmpDir = await fs.mkdtemp(join(tmpdir(), 'marplint-font-'));
-  const tmpHtmlPath = join(tmpDir, 'output.html');
-
-  try {
-    const absolutePath = resolve(markdownPath);
-    execSync(
-      `bunx --bun @marp-team/marp-cli@latest --no-stdin --html --allow-local-files "${absolutePath}" -o "${tmpHtmlPath}"`,
-      { stdio: 'pipe', encoding: 'utf-8' }
-    );
-
-    const htmlContent = await fs.readFile(tmpHtmlPath, 'utf-8');
-
-    const browserPath = detectInstalledBrowser();
-    const launchOptions: { headless: boolean; executablePath?: string } = { headless: true };
-    if (browserPath) {
-      launchOptions.executablePath = browserPath;
-    }
-
-    const browser = await chromium.launch(launchOptions);
-
-    try {
-      const page = await browser.newPage();
-      await page.setViewportSize({
-        width: mergedConfig.viewport.width,
-        height: mergedConfig.viewport.height
-      });
-
-      await page.setContent(htmlContent, { waitUntil: 'networkidle' });
-
-      const results = await page.evaluate((minSize: number) => {
-        const sections = Array.from(document.querySelectorAll('section'));
-
-        return sections.map((section, index) => {
-          const textElements = section.querySelectorAll('*');
-          const fontSizes: number[] = [];
-          const smallElements: Array<{ text: string; fontSize: number }> = [];
-
-          textElements.forEach((el) => {
-            const style = window.getComputedStyle(el);
-            const fontSize = parseFloat(style.fontSize);
-            const text = (el as HTMLElement).innerText?.trim().substring(0, 30) || '';
-
-            if (text && fontSize > 0) {
-              fontSizes.push(fontSize);
-              if (fontSize < minSize) {
-                smallElements.push({ text, fontSize: Math.round(fontSize) });
-              }
-            }
-          });
-
-          const minFontSize = fontSizes.length > 0 ? Math.min(...fontSizes) : 0;
-          const avgFontSize = fontSizes.length > 0
-            ? fontSizes.reduce((a, b) => a + b, 0) / fontSizes.length
-            : 0;
-
-          return {
-            slideNumber: index + 1,
-            minFontSize: Math.round(minFontSize),
-            avgFontSize: Math.round(avgFontSize),
-            smallTextCount: smallElements.length,
-            elements: smallElements.slice(0, 3) // Limit to first 3
-          };
-        });
-      }, mergedConfig.warnFontSize) as FontReadabilityResult[];
-
-      const errors: LintError[] = [];
-      for (const result of results) {
-        if (result.minFontSize > 0 && result.minFontSize < mergedConfig.minFontSize) {
-          errors.push({
-            ruleId: 'marp/font-readability',
-            slideNumber: result.slideNumber,
-            lineNumber: 0,
-            message: `Slide ${result.slideNumber}: Font size ${result.minFontSize}px is below minimum (${mergedConfig.minFontSize}px). Text may be unreadable.`,
-            severity: 'error'
-          });
-        } else if (result.minFontSize > 0 && result.minFontSize < mergedConfig.warnFontSize) {
-          errors.push({
-            ruleId: 'marp/font-readability',
-            slideNumber: result.slideNumber,
-            lineNumber: 0,
-            message: `Slide ${result.slideNumber}: Small font detected (${result.minFontSize}px). Consider using larger text for better readability.`,
-            severity: 'warning'
-          });
-        }
-      }
-
-      return { errors, results };
-
-    } finally {
-      await browser.close();
-    }
-
-  } finally {
-    try {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    } catch { /* ignore */ }
-  }
+  return fontReadabilityChecker.check(markdownPath, config);
 }

--- a/src/visual/index.ts
+++ b/src/visual/index.ts
@@ -2,6 +2,20 @@
  * Visual rules for marplint (Playwright-based)
  */
 
+// Base class and utilities
+export {
+  BaseVisualRule,
+  type BaseVisualConfig,
+  type VisualCheckResult,
+  detectInstalledBrowser,
+  buildMarpHtml,
+  launchBrowser,
+  setupPage,
+  cleanupTmpDir,
+  getMergedViewport
+} from './base-visual-rule.js';
+
+// Visual rules
 export { checkOverflow, type OverflowCheckerConfig, type OverflowResult } from './overflow-checker.js';
 export { checkWhitespace, type WhitespaceCheckerConfig, type WhitespaceResult } from './whitespace-checker.js';
 export { checkFontReadability, type FontReadabilityConfig, type FontReadabilityResult } from './font-readability.js';

--- a/src/visual/overflow-checker.ts
+++ b/src/visual/overflow-checker.ts
@@ -3,20 +3,12 @@
  * Renders slides and detects actual pixel overflow
  */
 
-import { chromium, type Browser, type Page } from 'playwright';
-import { execSync } from 'child_process';
-import { promises as fs } from 'fs';
-import { tmpdir } from 'os';
-import { join, resolve } from 'path';
+import type { Page } from 'playwright';
+import { BaseVisualRule, type BaseVisualConfig } from './base-visual-rule.js';
 import type { LintError } from '../rules/slide-line-count.js';
 
-export interface OverflowCheckerConfig {
-  enabled?: boolean;
+export interface OverflowCheckerConfig extends BaseVisualConfig {
   threshold?: number; // Minimum overflow in pixels to report
-  viewport?: {
-    width?: number;
-    height?: number;
-  };
 }
 
 export interface OverflowResult {
@@ -41,40 +33,71 @@ const DEFAULT_CONFIG: Required<OverflowCheckerConfig> = {
   }
 };
 
-/**
- * Detect installed Chromium-based browser
- */
-function detectInstalledBrowser(): string | null {
-  const browserPaths = [
-    '/usr/bin/google-chrome',
-    '/usr/bin/google-chrome-stable',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser',
-    '/opt/google/chrome/chrome',
-    '/usr/bin/microsoft-edge',
-    '/usr/bin/microsoft-edge-stable',
-    '/snap/bin/chromium',
-  ];
+class OverflowCheckerRule extends BaseVisualRule<OverflowCheckerConfig, OverflowResult> {
+  protected readonly tmpPrefix = 'overflow';
+  protected readonly defaultConfig = DEFAULT_CONFIG;
 
-  const existsSync = require('fs').existsSync;
-  for (const browserPath of browserPaths) {
-    if (existsSync(browserPath)) {
-      return browserPath;
-    }
+  protected async analyze(page: Page): Promise<OverflowResult[]> {
+    return await page.evaluate(() => {
+      const sections = Array.from(document.querySelectorAll('section'));
+      return sections.map((section, index): OverflowResult => {
+        const scrollHeight = section.scrollHeight;
+        const clientHeight = section.clientHeight;
+        const scrollWidth = section.scrollWidth;
+        const clientWidth = section.clientWidth;
+        const dataClass = section.getAttribute('data-class') || '';
+        const textContent = section.textContent?.trim().substring(0, 50).replace(/\n/g, ' ') || '';
+
+        const hasVerticalOverflow = scrollHeight > clientHeight;
+        const hasHorizontalOverflow = scrollWidth > clientWidth;
+
+        return {
+          slideNumber: index + 1,
+          hasOverflow: hasVerticalOverflow || hasHorizontalOverflow,
+          hasVerticalOverflow,
+          hasHorizontalOverflow,
+          overflowHeight: scrollHeight - clientHeight,
+          overflowWidth: scrollWidth - clientWidth,
+          scrollHeight,
+          clientHeight,
+          preview: textContent,
+          dataClass: dataClass || undefined
+        };
+      });
+    }) as OverflowResult[];
   }
 
-  const commands = ['google-chrome', 'chromium', 'chromium-browser', 'microsoft-edge'];
-  for (const cmd of commands) {
-    try {
-      const result = execSync(`which ${cmd}`, { encoding: 'utf-8' }).trim();
-      if (result) return result;
-    } catch {
-      continue;
-    }
-  }
+  protected convertToErrors(results: OverflowResult[], config: Required<OverflowCheckerConfig>): LintError[] {
+    const errors: LintError[] = [];
 
-  return null;
+    for (const result of results) {
+      if (result.hasVerticalOverflow && result.overflowHeight > config.threshold) {
+        errors.push({
+          ruleId: 'marp/overflow',
+          slideNumber: result.slideNumber,
+          lineNumber: 0,
+          message: `Slide ${result.slideNumber} has vertical overflow of ${result.overflowHeight}px. Content exceeds slide height.`,
+          severity: 'error'
+        });
+      }
+
+      if (result.hasHorizontalOverflow && result.overflowWidth > config.threshold) {
+        errors.push({
+          ruleId: 'marp/overflow',
+          slideNumber: result.slideNumber,
+          lineNumber: 0,
+          message: `Slide ${result.slideNumber} has horizontal overflow of ${result.overflowWidth}px. Content exceeds slide width.`,
+          severity: 'error'
+        });
+      }
+    }
+
+    return errors;
+  }
 }
+
+// Singleton instance
+const overflowChecker = new OverflowCheckerRule();
 
 /**
  * Check for overflow in a single markdown file
@@ -83,113 +106,5 @@ export async function checkOverflow(
   markdownPath: string,
   config: OverflowCheckerConfig = {}
 ): Promise<{ errors: LintError[]; results: OverflowResult[] }> {
-  const mergedConfig = {
-    ...DEFAULT_CONFIG,
-    viewport: { ...DEFAULT_CONFIG.viewport, ...config.viewport }
-  };
-
-  if (!mergedConfig.enabled) {
-    return { errors: [], results: [] };
-  }
-
-  // Create temp directory for HTML
-  const tmpDir = await fs.mkdtemp(join(tmpdir(), 'marplint-'));
-  const tmpHtmlPath = join(tmpDir, 'output.html');
-
-  try {
-    // Build with Marp CLI
-    const absolutePath = resolve(markdownPath);
-    execSync(
-      `bunx --bun @marp-team/marp-cli@latest --no-stdin --html --allow-local-files "${absolutePath}" -o "${tmpHtmlPath}"`,
-      { stdio: 'pipe', encoding: 'utf-8' }
-    );
-
-    // Read HTML content
-    const htmlContent = await fs.readFile(tmpHtmlPath, 'utf-8');
-
-    // Launch browser
-    const browserPath = detectInstalledBrowser();
-    const launchOptions: { headless: boolean; executablePath?: string } = { headless: true };
-    if (browserPath) {
-      launchOptions.executablePath = browserPath;
-    }
-
-    const browser = await chromium.launch(launchOptions);
-
-    try {
-      const page = await browser.newPage();
-      await page.setViewportSize({
-        width: mergedConfig.viewport.width,
-        height: mergedConfig.viewport.height
-      });
-
-      await page.setContent(htmlContent, { waitUntil: 'networkidle' });
-
-      // Check overflow for each slide
-      const results = await page.evaluate(() => {
-        const sections = Array.from(document.querySelectorAll('section'));
-        return sections.map((section, index): OverflowResult => {
-          const scrollHeight = section.scrollHeight;
-          const clientHeight = section.clientHeight;
-          const scrollWidth = section.scrollWidth;
-          const clientWidth = section.clientWidth;
-          const dataClass = section.getAttribute('data-class') || '';
-          const textContent = section.textContent?.trim().substring(0, 50).replace(/\n/g, ' ') || '';
-
-          const hasVerticalOverflow = scrollHeight > clientHeight;
-          const hasHorizontalOverflow = scrollWidth > clientWidth;
-
-          return {
-            slideNumber: index + 1,
-            hasOverflow: hasVerticalOverflow || hasHorizontalOverflow,
-            hasVerticalOverflow,
-            hasHorizontalOverflow,
-            overflowHeight: scrollHeight - clientHeight,
-            overflowWidth: scrollWidth - clientWidth,
-            scrollHeight,
-            clientHeight,
-            preview: textContent,
-            dataClass: dataClass || undefined
-          };
-        });
-      }) as OverflowResult[];
-
-      // Convert to lint errors
-      const errors: LintError[] = [];
-      for (const result of results) {
-        if (result.hasVerticalOverflow && result.overflowHeight > mergedConfig.threshold) {
-          errors.push({
-            ruleId: 'marp/overflow',
-            slideNumber: result.slideNumber,
-            lineNumber: 0, // Visual rules don't have line numbers
-            message: `Slide ${result.slideNumber} has vertical overflow of ${result.overflowHeight}px. Content exceeds slide height.`,
-            severity: 'error'
-          });
-        }
-
-        if (result.hasHorizontalOverflow && result.overflowWidth > mergedConfig.threshold) {
-          errors.push({
-            ruleId: 'marp/overflow',
-            slideNumber: result.slideNumber,
-            lineNumber: 0,
-            message: `Slide ${result.slideNumber} has horizontal overflow of ${result.overflowWidth}px. Content exceeds slide width.`,
-            severity: 'error'
-          });
-        }
-      }
-
-      return { errors, results };
-
-    } finally {
-      await browser.close();
-    }
-
-  } finally {
-    // Cleanup temp files
-    try {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-  }
+  return overflowChecker.check(markdownPath, config);
 }

--- a/src/visual/text-truncation.ts
+++ b/src/visual/text-truncation.ts
@@ -3,20 +3,11 @@
  * Detects text that may be truncated or cut off
  */
 
-import { chromium } from 'playwright';
-import { execSync } from 'child_process';
-import { promises as fs } from 'fs';
-import { tmpdir } from 'os';
-import { join, resolve } from 'path';
+import type { Page } from 'playwright';
+import { BaseVisualRule, type BaseVisualConfig } from './base-visual-rule.js';
 import type { LintError } from '../rules/slide-line-count.js';
 
-export interface TextTruncationConfig {
-  enabled?: boolean;
-  viewport?: {
-    width?: number;
-    height?: number;
-  };
-}
+export interface TextTruncationConfig extends BaseVisualConfig {}
 
 export interface TextTruncationResult {
   slideNumber: number;
@@ -35,138 +26,90 @@ const DEFAULT_CONFIG: Required<TextTruncationConfig> = {
   }
 };
 
-function detectInstalledBrowser(): string | null {
-  const browserPaths = [
-    '/usr/bin/google-chrome',
-    '/usr/bin/google-chrome-stable',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser',
-    '/snap/bin/chromium',
-  ];
+class TextTruncationRule extends BaseVisualRule<TextTruncationConfig, TextTruncationResult> {
+  protected readonly tmpPrefix = 'trunc';
+  protected readonly defaultConfig = DEFAULT_CONFIG;
 
-  const existsSync = require('fs').existsSync;
-  for (const browserPath of browserPaths) {
-    if (existsSync(browserPath)) {
-      return browserPath;
-    }
-  }
-  return null;
-}
+  protected async analyze(page: Page): Promise<TextTruncationResult[]> {
+    return await page.evaluate(() => {
+      const sections = Array.from(document.querySelectorAll('section'));
 
-export async function checkTextTruncation(
-  markdownPath: string,
-  config: TextTruncationConfig = {}
-): Promise<{ errors: LintError[]; results: TextTruncationResult[] }> {
-  const mergedConfig = {
-    ...DEFAULT_CONFIG,
-    viewport: { ...DEFAULT_CONFIG.viewport, ...config.viewport }
-  };
+      return sections.map((section, index) => {
+        const truncatedElements: Array<{
+          text: string;
+          scrollWidth: number;
+          clientWidth: number;
+        }> = [];
 
-  if (!mergedConfig.enabled) {
-    return { errors: [], results: [] };
-  }
+        // Check text elements for horizontal overflow (truncation)
+        const textElements = section.querySelectorAll('p, li, td, th, h1, h2, h3, h4, h5, h6, span');
 
-  const tmpDir = await fs.mkdtemp(join(tmpdir(), 'marplint-trunc-'));
-  const tmpHtmlPath = join(tmpDir, 'output.html');
+        textElements.forEach((el) => {
+          const htmlEl = el as HTMLElement;
+          const text = htmlEl.innerText?.trim().substring(0, 40) || '';
+          if (!text) return;
 
-  try {
-    const absolutePath = resolve(markdownPath);
-    execSync(
-      `bunx --bun @marp-team/marp-cli@latest --no-stdin --html --allow-local-files "${absolutePath}" -o "${tmpHtmlPath}"`,
-      { stdio: 'pipe', encoding: 'utf-8' }
-    );
+          // Check for horizontal overflow
+          if (htmlEl.scrollWidth > htmlEl.clientWidth + 5) { // 5px tolerance
+            truncatedElements.push({
+              text,
+              scrollWidth: htmlEl.scrollWidth,
+              clientWidth: htmlEl.clientWidth
+            });
+          }
 
-    const htmlContent = await fs.readFile(tmpHtmlPath, 'utf-8');
-
-    const browserPath = detectInstalledBrowser();
-    const launchOptions: { headless: boolean; executablePath?: string } = { headless: true };
-    if (browserPath) {
-      launchOptions.executablePath = browserPath;
-    }
-
-    const browser = await chromium.launch(launchOptions);
-
-    try {
-      const page = await browser.newPage();
-      await page.setViewportSize({
-        width: mergedConfig.viewport.width,
-        height: mergedConfig.viewport.height
-      });
-
-      await page.setContent(htmlContent, { waitUntil: 'networkidle' });
-
-      const results = await page.evaluate(() => {
-        const sections = Array.from(document.querySelectorAll('section'));
-
-        return sections.map((section, index) => {
-          const truncatedElements: Array<{
-            text: string;
-            scrollWidth: number;
-            clientWidth: number;
-          }> = [];
-
-          // Check text elements for horizontal overflow (truncation)
-          const textElements = section.querySelectorAll('p, li, td, th, h1, h2, h3, h4, h5, h6, span');
-
-          textElements.forEach((el) => {
-            const htmlEl = el as HTMLElement;
-            const text = htmlEl.innerText?.trim().substring(0, 40) || '';
-            if (!text) return;
-
-            // Check for horizontal overflow
-            if (htmlEl.scrollWidth > htmlEl.clientWidth + 5) { // 5px tolerance
+          // Check for text-overflow: ellipsis being applied
+          const style = window.getComputedStyle(htmlEl);
+          if (style.textOverflow === 'ellipsis' && style.overflow === 'hidden') {
+            if (htmlEl.scrollWidth > htmlEl.clientWidth) {
               truncatedElements.push({
                 text,
                 scrollWidth: htmlEl.scrollWidth,
                 clientWidth: htmlEl.clientWidth
               });
             }
-
-            // Check for text-overflow: ellipsis being applied
-            const style = window.getComputedStyle(htmlEl);
-            if (style.textOverflow === 'ellipsis' && style.overflow === 'hidden') {
-              if (htmlEl.scrollWidth > htmlEl.clientWidth) {
-                truncatedElements.push({
-                  text,
-                  scrollWidth: htmlEl.scrollWidth,
-                  clientWidth: htmlEl.clientWidth
-                });
-              }
-            }
-          });
-
-          return {
-            slideNumber: index + 1,
-            truncatedElements: truncatedElements.slice(0, 3)
-          };
-        });
-      }) as TextTruncationResult[];
-
-      const errors: LintError[] = [];
-      for (const result of results) {
-        if (result.truncatedElements.length > 0) {
-          const element = result.truncatedElements[0];
-          if (element) {
-            errors.push({
-              ruleId: 'marp/text-truncation',
-              slideNumber: result.slideNumber,
-              lineNumber: 0,
-              message: `Slide ${result.slideNumber}: Text may be truncated. "${element.text}..." exceeds container width.`,
-              severity: 'warning'
-            });
           }
+        });
+
+        return {
+          slideNumber: index + 1,
+          truncatedElements: truncatedElements.slice(0, 3)
+        };
+      });
+    }) as TextTruncationResult[];
+  }
+
+  protected convertToErrors(results: TextTruncationResult[]): LintError[] {
+    const errors: LintError[] = [];
+
+    for (const result of results) {
+      if (result.truncatedElements.length > 0) {
+        const element = result.truncatedElements[0];
+        if (element) {
+          errors.push({
+            ruleId: 'marp/text-truncation',
+            slideNumber: result.slideNumber,
+            lineNumber: 0,
+            message: `Slide ${result.slideNumber}: Text may be truncated. "${element.text}..." exceeds container width.`,
+            severity: 'warning'
+          });
         }
       }
-
-      return { errors, results };
-
-    } finally {
-      await browser.close();
     }
 
-  } finally {
-    try {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    } catch { /* ignore */ }
+    return errors;
   }
+}
+
+// Singleton instance
+const textTruncationChecker = new TextTruncationRule();
+
+/**
+ * Check for text truncation in slides
+ */
+export async function checkTextTruncation(
+  markdownPath: string,
+  config: TextTruncationConfig = {}
+): Promise<{ errors: LintError[]; results: TextTruncationResult[] }> {
+  return textTruncationChecker.check(markdownPath, config);
 }

--- a/src/visual/whitespace-checker.ts
+++ b/src/visual/whitespace-checker.ts
@@ -3,20 +3,12 @@
  * Detects slides with excessive unused space
  */
 
-import { chromium } from 'playwright';
-import { execSync } from 'child_process';
-import { promises as fs } from 'fs';
-import { tmpdir } from 'os';
-import { join, resolve } from 'path';
+import type { Page } from 'playwright';
+import { BaseVisualRule, type BaseVisualConfig } from './base-visual-rule.js';
 import type { LintError } from '../rules/slide-line-count.js';
 
-export interface WhitespaceCheckerConfig {
-  enabled?: boolean;
+export interface WhitespaceCheckerConfig extends BaseVisualConfig {
   minUtilization?: number; // Minimum content utilization (0.0 - 1.0)
-  viewport?: {
-    width?: number;
-    height?: number;
-  };
 }
 
 export interface WhitespaceResult {
@@ -38,39 +30,63 @@ const DEFAULT_CONFIG: Required<WhitespaceCheckerConfig> = {
   }
 };
 
-/**
- * Detect installed Chromium-based browser
- */
-function detectInstalledBrowser(): string | null {
-  const browserPaths = [
-    '/usr/bin/google-chrome',
-    '/usr/bin/google-chrome-stable',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser',
-    '/opt/google/chrome/chrome',
-    '/usr/bin/microsoft-edge',
-    '/snap/bin/chromium',
-  ];
+class WhitespaceCheckerRule extends BaseVisualRule<WhitespaceCheckerConfig, WhitespaceResult> {
+  protected readonly tmpPrefix = 'ws';
+  protected readonly defaultConfig = DEFAULT_CONFIG;
 
-  const existsSync = require('fs').existsSync;
-  for (const browserPath of browserPaths) {
-    if (existsSync(browserPath)) {
-      return browserPath;
-    }
+  protected async analyze(page: Page): Promise<WhitespaceResult[]> {
+    return await page.evaluate(() => {
+      const sections = Array.from(document.querySelectorAll('section'));
+      return sections.map((section, index) => {
+        const scrollHeight = section.scrollHeight;
+        const clientHeight = section.clientHeight;
+        const dataClass = section.getAttribute('data-class') || '';
+        const textContent = section.textContent?.trim().substring(0, 50).replace(/\n/g, ' ') || '';
+
+        // Calculate content utilization
+        const utilization = scrollHeight / clientHeight;
+
+        return {
+          slideNumber: index + 1,
+          utilization,
+          scrollHeight,
+          clientHeight,
+          isSparse: utilization < 0.5, // Will be adjusted based on config
+          preview: textContent,
+          dataClass: dataClass || undefined
+        };
+      });
+    }) as WhitespaceResult[];
   }
 
-  const commands = ['google-chrome', 'chromium', 'chromium-browser', 'microsoft-edge'];
-  for (const cmd of commands) {
-    try {
-      const result = execSync(`which ${cmd}`, { encoding: 'utf-8' }).trim();
-      if (result) return result;
-    } catch {
-      continue;
-    }
-  }
+  protected convertToErrors(results: WhitespaceResult[], config: Required<WhitespaceCheckerConfig>): LintError[] {
+    const errors: LintError[] = [];
 
-  return null;
+    for (const result of results) {
+      // Skip title/intro slides (usually sparse by design)
+      if (result.slideNumber === 1) continue;
+
+      // Update isSparse based on config
+      result.isSparse = result.utilization < config.minUtilization;
+
+      if (result.isSparse) {
+        const utilizationPercent = Math.round(result.utilization * 100);
+        errors.push({
+          ruleId: 'marp/whitespace',
+          slideNumber: result.slideNumber,
+          lineNumber: 0,
+          message: `Slide ${result.slideNumber} has low content utilization (${utilizationPercent}%). Consider adding more content or merging with another slide.`,
+          severity: 'warning'
+        });
+      }
+    }
+
+    return errors;
+  }
 }
+
+// Singleton instance
+const whitespaceChecker = new WhitespaceCheckerRule();
 
 /**
  * Check for excessive whitespace in slides
@@ -79,106 +95,5 @@ export async function checkWhitespace(
   markdownPath: string,
   config: WhitespaceCheckerConfig = {}
 ): Promise<{ errors: LintError[]; results: WhitespaceResult[] }> {
-  const mergedConfig = {
-    ...DEFAULT_CONFIG,
-    viewport: { ...DEFAULT_CONFIG.viewport, ...config.viewport }
-  };
-
-  if (!mergedConfig.enabled) {
-    return { errors: [], results: [] };
-  }
-
-  // Create temp directory for HTML
-  const tmpDir = await fs.mkdtemp(join(tmpdir(), 'marplint-ws-'));
-  const tmpHtmlPath = join(tmpDir, 'output.html');
-
-  try {
-    // Build with Marp CLI
-    const absolutePath = resolve(markdownPath);
-    execSync(
-      `bunx --bun @marp-team/marp-cli@latest --no-stdin --html --allow-local-files "${absolutePath}" -o "${tmpHtmlPath}"`,
-      { stdio: 'pipe', encoding: 'utf-8' }
-    );
-
-    // Read HTML content
-    const htmlContent = await fs.readFile(tmpHtmlPath, 'utf-8');
-
-    // Launch browser
-    const browserPath = detectInstalledBrowser();
-    const launchOptions: { headless: boolean; executablePath?: string } = { headless: true };
-    if (browserPath) {
-      launchOptions.executablePath = browserPath;
-    }
-
-    const browser = await chromium.launch(launchOptions);
-
-    try {
-      const page = await browser.newPage();
-      await page.setViewportSize({
-        width: mergedConfig.viewport.width,
-        height: mergedConfig.viewport.height
-      });
-
-      await page.setContent(htmlContent, { waitUntil: 'networkidle' });
-
-      // Check whitespace for each slide
-      const results = await page.evaluate(() => {
-        const sections = Array.from(document.querySelectorAll('section'));
-        return sections.map((section, index) => {
-          const scrollHeight = section.scrollHeight;
-          const clientHeight = section.clientHeight;
-          const dataClass = section.getAttribute('data-class') || '';
-          const textContent = section.textContent?.trim().substring(0, 50).replace(/\n/g, ' ') || '';
-
-          // Calculate content utilization
-          // This is a simplified metric - actual content height vs available height
-          const utilization = scrollHeight / clientHeight;
-
-          return {
-            slideNumber: index + 1,
-            utilization,
-            scrollHeight,
-            clientHeight,
-            isSparse: utilization < 0.5, // Will be adjusted based on config
-            preview: textContent,
-            dataClass: dataClass || undefined
-          };
-        });
-      }) as WhitespaceResult[];
-
-      // Apply config threshold and convert to lint errors
-      const errors: LintError[] = [];
-      for (const result of results) {
-        // Skip title/intro slides (usually sparse by design)
-        if (result.slideNumber === 1) continue;
-
-        // Update isSparse based on config
-        result.isSparse = result.utilization < mergedConfig.minUtilization;
-
-        if (result.isSparse) {
-          const utilizationPercent = Math.round(result.utilization * 100);
-          errors.push({
-            ruleId: 'marp/whitespace',
-            slideNumber: result.slideNumber,
-            lineNumber: 0, // Visual rules don't have line numbers
-            message: `Slide ${result.slideNumber} has low content utilization (${utilizationPercent}%). Consider adding more content or merging with another slide.`,
-            severity: 'warning'
-          });
-        }
-      }
-
-      return { errors, results };
-
-    } finally {
-      await browser.close();
-    }
-
-  } finally {
-    // Cleanup temp files
-    try {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-  }
+  return whitespaceChecker.check(markdownPath, config);
 }


### PR DESCRIPTION
## Summary
- `BaseVisualRule`抽象クラスを追加し、6つの視覚ルールの共通処理を集約
- `detectInstalledBrowser()`, `buildMarpHtml()`, `launchBrowser()`などのユーティリティ関数を基底クラスに移動
- 各ルールは`analyze()`と`convertToErrors()`メソッドのみを実装する形にリファクタリング
- 約186行のコード削減を達成

## Test plan
- [ ] 型チェックが通ること（`bunx tsc --noEmit`）
- [ ] 実際のMarkdownファイルで各視覚ルールが動作すること
- [ ] 既存のAPI互換性が維持されていること

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)