### PR TITLE
refactor: Visitorパターンで静的ルールの重複ループを削減

### DIFF
--- a/src/rules/code-block-length.ts
+++ b/src/rules/code-block-length.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LintError } from './slide-line-count.js';
+import { visitSlides, type LineContext } from '../utils/slide-visitor.js';
 
 export interface CodeBlockLengthConfig {
   enabled?: boolean;
@@ -17,14 +18,6 @@ const DEFAULT_CONFIG: Required<CodeBlockLengthConfig> = {
   maxLineLength: 80
 };
 
-interface CodeBlock {
-  startLine: number;
-  endLine: number;
-  lines: string[];
-  language: string;
-  slideNumber: number;
-}
-
 export function codeBlockLength(
   content: string,
   config: CodeBlockLengthConfig = {}
@@ -35,96 +28,37 @@ export function codeBlockLength(
     return [];
   }
 
-  const lines = content.split('\n');
   const errors: LintError[] = [];
-  let currentSlide = 1;
-  let inFrontmatter = false;
-  let inCodeBlock = false;
-  let codeBlockStart = 0;
-  let codeBlockLanguage = '';
-  let codeBlockLines: string[] = [];
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
-    const lineNumber = i + 1;
+  visitSlides(content, {
+    onCodeBlockEnd(lines: string[], language: string, startLine: number, context: LineContext) {
+      // Check line count
+      if (lines.length > mergedConfig.maxLines) {
+        errors.push({
+          ruleId: 'marp/code-block-length',
+          slideNumber: context.slideNumber,
+          lineNumber: startLine,
+          message: `Slide ${context.slideNumber}: Code block has ${lines.length} lines (max: ${mergedConfig.maxLines}). Consider splitting or using a smaller font.`,
+          severity: 'warning'
+        });
+      }
 
-    // Track frontmatter
-    if (line.trim() === '---') {
-      if (i === 0) {
-        inFrontmatter = true;
-        continue;
-      } else if (inFrontmatter) {
-        inFrontmatter = false;
-        continue;
-      } else {
-        currentSlide++;
-        continue;
+      // Check line length
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i] ?? '';
+        if (line.length > mergedConfig.maxLineLength) {
+          errors.push({
+            ruleId: 'marp/code-block-length',
+            slideNumber: context.slideNumber,
+            lineNumber: startLine + i + 1,
+            message: `Slide ${context.slideNumber}: Code line ${i + 1} has ${line.length} characters (max: ${mergedConfig.maxLineLength}). Line may be truncated.`,
+            severity: 'warning'
+          });
+          break; // Only report first occurrence per block
+        }
       }
     }
-
-    if (inFrontmatter) continue;
-
-    // Track code blocks
-    const codeBlockMatch = line.match(/^```(\w*)/);
-    if (codeBlockMatch) {
-      if (!inCodeBlock) {
-        // Start of code block
-        inCodeBlock = true;
-        codeBlockStart = lineNumber;
-        codeBlockLanguage = codeBlockMatch[1] ?? '';
-        codeBlockLines = [];
-      } else {
-        // End of code block
-        inCodeBlock = false;
-
-        // Validate code block
-        validateCodeBlock({
-          startLine: codeBlockStart,
-          endLine: lineNumber,
-          lines: codeBlockLines,
-          language: codeBlockLanguage,
-          slideNumber: currentSlide
-        }, errors, mergedConfig);
-      }
-      continue;
-    }
-
-    if (inCodeBlock) {
-      codeBlockLines.push(line);
-    }
-  }
+  });
 
   return errors;
-}
-
-function validateCodeBlock(
-  block: CodeBlock,
-  errors: LintError[],
-  config: Required<CodeBlockLengthConfig>
-): void {
-  // Check line count
-  if (block.lines.length > config.maxLines) {
-    errors.push({
-      ruleId: 'marp/code-block-length',
-      slideNumber: block.slideNumber,
-      lineNumber: block.startLine,
-      message: `Slide ${block.slideNumber}: Code block has ${block.lines.length} lines (max: ${config.maxLines}). Consider splitting or using a smaller font.`,
-      severity: 'warning'
-    });
-  }
-
-  // Check line length
-  for (let i = 0; i < block.lines.length; i++) {
-    const line = block.lines[i] ?? '';
-    if (line.length > config.maxLineLength) {
-      errors.push({
-        ruleId: 'marp/code-block-length',
-        slideNumber: block.slideNumber,
-        lineNumber: block.startLine + i + 1,
-        message: `Slide ${block.slideNumber}: Code line ${i + 1} has ${line.length} characters (max: ${config.maxLineLength}). Line may be truncated.`,
-        severity: 'warning'
-      });
-      break; // Only report first occurrence per block
-    }
-  }
 }

--- a/src/rules/duplicate-content.ts
+++ b/src/rules/duplicate-content.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LintError } from './slide-line-count.js';
+import { visitSlides, type LineContext } from '../utils/slide-visitor.js';
 
 export interface DuplicateContentConfig {
   enabled?: boolean;
@@ -78,68 +79,41 @@ export function duplicateContent(
 }
 
 function parseSlides(content: string): SlideContent[] {
-  const lines = content.split('\n');
   const slides: SlideContent[] = [];
-  let currentSlide = 1;
-  let slideStartLine = 1;
-  let inFrontmatter = false;
   let slideLines: string[] = [];
   let title = '';
+  let slideStartLine = 1;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
+  visitSlides(content, {
+    onSlideStart(slideNumber: number, startLine: number) {
+      slideLines = [];
+      title = '';
+      slideStartLine = startLine;
+    },
 
-    // Track frontmatter
-    if (line.trim() === '---') {
-      if (i === 0) {
-        inFrontmatter = true;
-        continue;
-      } else if (inFrontmatter) {
-        inFrontmatter = false;
-        continue;
-      } else {
-        // End of slide
-        if (slideLines.length > 0) {
-          const slideContent = slideLines.join('\n');
-          slides.push({
-            slideNumber: currentSlide,
-            startLine: slideStartLine,
-            title,
-            content: slideContent,
-            normalizedContent: normalizeContent(slideContent)
-          });
-        }
-
-        currentSlide++;
-        slideStartLine = i + 2;
-        slideLines = [];
-        title = '';
-        continue;
+    onSlideEnd(slideNumber: number) {
+      if (slideLines.length > 0) {
+        const slideContent = slideLines.join('\n');
+        slides.push({
+          slideNumber,
+          startLine: slideStartLine,
+          title,
+          content: slideContent,
+          normalizedContent: normalizeContent(slideContent)
+        });
       }
+    },
+
+    onHeading(_level: number, text: string, _context: LineContext) {
+      if (!title) {
+        title = text;
+      }
+    },
+
+    onLine(line: string, _context: LineContext) {
+      slideLines.push(line);
     }
-
-    if (inFrontmatter) continue;
-
-    // Extract title
-    const headingMatch = line.match(/^#+\s+(.+)$/);
-    if (headingMatch && !title) {
-      title = headingMatch[1] ?? '';
-    }
-
-    slideLines.push(line);
-  }
-
-  // Add last slide
-  if (slideLines.length > 0) {
-    const slideContent = slideLines.join('\n');
-    slides.push({
-      slideNumber: currentSlide,
-      startLine: slideStartLine,
-      title,
-      content: slideContent,
-      normalizedContent: normalizeContent(slideContent)
-    });
-  }
+  });
 
   return slides;
 }

--- a/src/rules/heading-hierarchy.ts
+++ b/src/rules/heading-hierarchy.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LintError } from './slide-line-count.js';
+import { visitSlides, type LineContext } from '../utils/slide-visitor.js';
 
 export interface HeadingHierarchyConfig {
   enabled?: boolean;
@@ -32,55 +33,29 @@ export function headingHierarchy(
     return [];
   }
 
-  const lines = content.split('\n');
   const errors: LintError[] = [];
-  let currentSlide = 1;
-  let inFrontmatter = false;
-  let inCodeBlock = false;
+  let headingsInSlide: Heading[] = [];
+  let currentSlide = 0;
 
-  const headingsInSlide: Heading[] = [];
+  visitSlides(content, {
+    onSlideStart(slideNumber: number) {
+      currentSlide = slideNumber;
+      headingsInSlide = [];
+    },
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
-    const lineNumber = i + 1;
+    onSlideEnd(slideNumber: number) {
+      validateSlideHeadings(headingsInSlide, errors, slideNumber, mergedConfig);
+    },
 
-    // Track frontmatter
-    if (line.trim() === '---') {
-      if (i === 0) {
-        inFrontmatter = true;
-        continue;
-      } else if (inFrontmatter) {
-        inFrontmatter = false;
-        continue;
-      } else {
-        // Slide break - validate headings in previous slide
-        validateSlideHeadings(headingsInSlide, errors, currentSlide, mergedConfig);
-        headingsInSlide.length = 0;
-        currentSlide++;
-        continue;
-      }
+    onHeading(level: number, text: string, context: LineContext) {
+      headingsInSlide.push({
+        level,
+        lineNumber: context.lineNumber,
+        text,
+        slideNumber: context.slideNumber
+      });
     }
-
-    if (inFrontmatter) continue;
-
-    // Track code blocks
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-
-    // Detect headings
-    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
-    if (headingMatch) {
-      const level = headingMatch[1]?.length ?? 0;
-      const text = headingMatch[2] ?? '';
-      headingsInSlide.push({ level, lineNumber, text, slideNumber: currentSlide });
-    }
-  }
-
-  // Validate last slide
-  validateSlideHeadings(headingsInSlide, errors, currentSlide, mergedConfig);
+  });
 
   return errors;
 }

--- a/src/rules/japanese-consistency.ts
+++ b/src/rules/japanese-consistency.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LintError } from './slide-line-count.js';
+import { visitSlides, type LineContext } from '../utils/slide-visitor.js';
 
 export interface JapaneseConsistencyConfig {
   enabled?: boolean;
@@ -25,19 +26,10 @@ const DEFAULT_CONFIG: Required<JapaneseConsistencyConfig> = {
 
 // Character patterns
 const FULL_WIDTH_NUMBERS = /[０-９]/g;
-const HALF_WIDTH_NUMBERS = /[0-9]/g;
 const FULL_WIDTH_ALPHABETS = /[Ａ-Ｚａ-ｚ]/g;
 const MIXED_PUNCTUATION = /[、。].*[,.]|[,.].*[、。]/;
 const FULL_WIDTH_PARENS = /[（）「」『』【】]/g;
 const HALF_WIDTH_PARENS = /[\(\)\[\]]/g;
-
-// Pattern for Japanese text followed/preceded by English without space
-const JAPANESE_CHAR = '[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]';
-const ENGLISH_CHAR = '[A-Za-z0-9]';
-const NO_SPACE_PATTERN = new RegExp(
-  `(${JAPANESE_CHAR})(${ENGLISH_CHAR})|(${ENGLISH_CHAR})(${JAPANESE_CHAR})`,
-  'g'
-);
 
 export function japaneseConsistency(
   content: string,
@@ -49,114 +41,76 @@ export function japaneseConsistency(
     return [];
   }
 
-  const lines = content.split('\n');
   const errors: LintError[] = [];
-  let currentSlide = 1;
-  let inFrontmatter = false;
-  let inCodeBlock = false;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
-    const lineNumber = i + 1;
+  visitSlides(content, {
+    onLine(line: string, context: LineContext) {
+      // Skip HTML comments
+      if (line.trim().startsWith('<!--')) return;
 
-    // Track frontmatter
-    if (line.trim() === '---') {
-      if (i === 0) {
-        inFrontmatter = true;
-        continue;
-      } else if (inFrontmatter) {
-        inFrontmatter = false;
-        continue;
-      } else {
-        currentSlide++;
-        continue;
+      // Skip URLs and code spans
+      const textToCheck = line
+        .replace(/`[^`]+`/g, '') // Remove inline code
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Keep link text only
+        .replace(/https?:\/\/[^\s]+/g, ''); // Remove URLs
+
+      // Check full-width numbers (if preferring half-width)
+      if (!mergedConfig.preferFullWidthNumbers) {
+        const fullWidthNums = textToCheck.match(FULL_WIDTH_NUMBERS);
+        if (fullWidthNums && fullWidthNums.length > 0) {
+          errors.push({
+            ruleId: 'marp/japanese-consistency',
+            slideNumber: context.slideNumber,
+            lineNumber: context.lineNumber,
+            message: `Slide ${context.slideNumber}: Full-width numbers found. Consider using half-width: ${fullWidthNums.join('')}`,
+            severity: 'warning'
+          });
+        }
       }
-    }
 
-    if (inFrontmatter) continue;
+      // Check full-width alphabets (if preferring half-width)
+      if (!mergedConfig.preferFullWidthAlphabets) {
+        const fullWidthAlpha = textToCheck.match(FULL_WIDTH_ALPHABETS);
+        if (fullWidthAlpha && fullWidthAlpha.length > 0) {
+          errors.push({
+            ruleId: 'marp/japanese-consistency',
+            slideNumber: context.slideNumber,
+            lineNumber: context.lineNumber,
+            message: `Slide ${context.slideNumber}: Full-width alphabets found. Consider using half-width: ${fullWidthAlpha.join('')}`,
+            severity: 'warning'
+          });
+        }
+      }
 
-    // Track code blocks
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-
-    // Skip HTML comments
-    if (line.trim().startsWith('<!--')) continue;
-
-    // Skip URLs and code spans
-    const textToCheck = line
-      .replace(/`[^`]+`/g, '') // Remove inline code
-      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Keep link text only
-      .replace(/https?:\/\/[^\s]+/g, ''); // Remove URLs
-
-    // Check full-width numbers (if preferring half-width)
-    if (!mergedConfig.preferFullWidthNumbers) {
-      const fullWidthNums = textToCheck.match(FULL_WIDTH_NUMBERS);
-      if (fullWidthNums && fullWidthNums.length > 0) {
+      // Check mixed punctuation
+      if (mergedConfig.checkPunctuation && MIXED_PUNCTUATION.test(textToCheck)) {
         errors.push({
           ruleId: 'marp/japanese-consistency',
-          slideNumber: currentSlide,
-          lineNumber,
-          message: `Slide ${currentSlide}: Full-width numbers found. Consider using half-width: ${fullWidthNums.join('')}`,
+          slideNumber: context.slideNumber,
+          lineNumber: context.lineNumber,
+          message: `Slide ${context.slideNumber}: Mixed Japanese and Western punctuation. Use consistent style.`,
           severity: 'warning'
         });
       }
-    }
 
-    // Check full-width alphabets (if preferring half-width)
-    if (!mergedConfig.preferFullWidthAlphabets) {
-      const fullWidthAlpha = textToCheck.match(FULL_WIDTH_ALPHABETS);
-      if (fullWidthAlpha && fullWidthAlpha.length > 0) {
-        errors.push({
-          ruleId: 'marp/japanese-consistency',
-          slideNumber: currentSlide,
-          lineNumber,
-          message: `Slide ${currentSlide}: Full-width alphabets found. Consider using half-width: ${fullWidthAlpha.join('')}`,
-          severity: 'warning'
-        });
+      // Check mixed parentheses in Japanese context
+      if (mergedConfig.checkParentheses) {
+        const hasFullWidthParens = FULL_WIDTH_PARENS.test(textToCheck);
+        const hasHalfWidthParens = HALF_WIDTH_PARENS.test(textToCheck);
+        const hasJapanese = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(textToCheck);
+
+        if (hasJapanese && hasFullWidthParens && hasHalfWidthParens) {
+          errors.push({
+            ruleId: 'marp/japanese-consistency',
+            slideNumber: context.slideNumber,
+            lineNumber: context.lineNumber,
+            message: `Slide ${context.slideNumber}: Mixed full-width and half-width parentheses. Consider using consistent style.`,
+            severity: 'warning'
+          });
+        }
       }
     }
-
-    // Check mixed punctuation
-    if (mergedConfig.checkPunctuation && MIXED_PUNCTUATION.test(textToCheck)) {
-      errors.push({
-        ruleId: 'marp/japanese-consistency',
-        slideNumber: currentSlide,
-        lineNumber,
-        message: `Slide ${currentSlide}: Mixed Japanese and Western punctuation. Use consistent style.`,
-        severity: 'warning'
-      });
-    }
-
-    // Check mixed parentheses in Japanese context
-    if (mergedConfig.checkParentheses) {
-      const hasFullWidthParens = FULL_WIDTH_PARENS.test(textToCheck);
-      const hasHalfWidthParens = HALF_WIDTH_PARENS.test(textToCheck);
-      const hasJapanese = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(textToCheck);
-
-      if (hasJapanese && hasFullWidthParens && hasHalfWidthParens) {
-        errors.push({
-          ruleId: 'marp/japanese-consistency',
-          slideNumber: currentSlide,
-          lineNumber,
-          message: `Slide ${currentSlide}: Mixed full-width and half-width parentheses. Consider using consistent style.`,
-          severity: 'warning'
-        });
-      }
-    }
-
-    // Check space around English in Japanese text
-    if (mergedConfig.checkSpaceAroundEnglish) {
-      const hasJapanese = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(textToCheck);
-      if (hasJapanese && NO_SPACE_PATTERN.test(textToCheck)) {
-        // This is actually a stylistic preference, so make it info-level
-        // Many Japanese texts don't use spaces around English words
-        // errors.push({...});
-      }
-    }
-  }
+  });
 
   return errors;
 }

--- a/src/rules/link-validity.ts
+++ b/src/rules/link-validity.ts
@@ -6,6 +6,7 @@
 import { existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import type { LintError } from './slide-line-count.js';
+import { visitSlides, type LineContext } from '../utils/slide-visitor.js';
 
 export interface LinkValidityConfig {
   enabled?: boolean;
@@ -42,11 +43,7 @@ export function linkValidity(
     return [];
   }
 
-  const lines = content.split('\n');
   const errors: LintError[] = [];
-  let currentSlide = 1;
-  let inFrontmatter = false;
-  let inCodeBlock = false;
 
   // Regex patterns for links and images
   const linkPattern = /\[([^\]]*)\]\(([^)]+)\)/g;
@@ -54,95 +51,74 @@ export function linkValidity(
   const htmlImgPattern = /<img[^>]+src=["']([^"']+)["'][^>]*>/g;
   const htmlLinkPattern = /<a[^>]+href=["']([^"']+)["'][^>]*>/g;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
-    const lineNumber = i + 1;
+  visitSlides(content, {
+    onLine(line: string, context: LineContext) {
+      const links: Link[] = [];
 
-    // Track frontmatter
-    if (line.trim() === '---') {
-      if (i === 0) {
-        inFrontmatter = true;
-        continue;
-      } else if (inFrontmatter) {
-        inFrontmatter = false;
-        continue;
-      } else {
-        currentSlide++;
-        continue;
+      // Markdown images
+      if (mergedConfig.checkImages) {
+        let match;
+        while ((match = imagePattern.exec(line)) !== null) {
+          links.push({
+            url: match[2] ?? '',
+            text: match[1] ?? '',
+            lineNumber: context.lineNumber,
+            slideNumber: context.slideNumber,
+            isImage: true
+          });
+        }
+        imagePattern.lastIndex = 0; // Reset regex state
       }
-    }
 
-    if (inFrontmatter) continue;
-
-    // Track code blocks
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-
-    // Extract links
-    const links: Link[] = [];
-
-    // Markdown images
-    if (mergedConfig.checkImages) {
+      // Markdown links
       let match;
-      while ((match = imagePattern.exec(line)) !== null) {
+      while ((match = linkPattern.exec(line)) !== null) {
+        // Skip if it's actually an image (starts with !)
+        const startIndex = match.index;
+        if (startIndex > 0 && line[startIndex - 1] === '!') continue;
+
         links.push({
           url: match[2] ?? '',
           text: match[1] ?? '',
-          lineNumber,
-          slideNumber: currentSlide,
-          isImage: true
+          lineNumber: context.lineNumber,
+          slideNumber: context.slideNumber,
+          isImage: false
         });
       }
-    }
+      linkPattern.lastIndex = 0; // Reset regex state
 
-    // Markdown links
-    let match;
-    while ((match = linkPattern.exec(line)) !== null) {
-      // Skip if it's actually an image (starts with !)
-      const startIndex = match.index;
-      if (startIndex > 0 && line[startIndex - 1] === '!') continue;
+      // HTML images
+      if (mergedConfig.checkImages) {
+        while ((match = htmlImgPattern.exec(line)) !== null) {
+          links.push({
+            url: match[1] ?? '',
+            text: '',
+            lineNumber: context.lineNumber,
+            slideNumber: context.slideNumber,
+            isImage: true
+          });
+        }
+        htmlImgPattern.lastIndex = 0; // Reset regex state
+      }
 
-      links.push({
-        url: match[2] ?? '',
-        text: match[1] ?? '',
-        lineNumber,
-        slideNumber: currentSlide,
-        isImage: false
-      });
-    }
-
-    // HTML images
-    if (mergedConfig.checkImages) {
-      while ((match = htmlImgPattern.exec(line)) !== null) {
+      // HTML links
+      while ((match = htmlLinkPattern.exec(line)) !== null) {
         links.push({
           url: match[1] ?? '',
           text: '',
-          lineNumber,
-          slideNumber: currentSlide,
-          isImage: true
+          lineNumber: context.lineNumber,
+          slideNumber: context.slideNumber,
+          isImage: false
         });
       }
-    }
+      htmlLinkPattern.lastIndex = 0; // Reset regex state
 
-    // HTML links
-    while ((match = htmlLinkPattern.exec(line)) !== null) {
-      links.push({
-        url: match[1] ?? '',
-        text: '',
-        lineNumber,
-        slideNumber: currentSlide,
-        isImage: false
-      });
+      // Validate each link
+      for (const link of links) {
+        validateLink(link, filePath, errors, mergedConfig);
+      }
     }
-
-    // Validate each link
-    for (const link of links) {
-      validateLink(link, filePath, errors, mergedConfig);
-    }
-  }
+  });
 
   return errors;
 }

--- a/src/rules/max-nested-list.ts
+++ b/src/rules/max-nested-list.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LintError } from './slide-line-count.js';
+import { visitSlides, type LineContext } from '../utils/slide-visitor.js';
 
 export interface MaxNestedListConfig {
   enabled?: boolean;
@@ -25,59 +26,23 @@ export function maxNestedList(
     return [];
   }
 
-  const lines = content.split('\n');
   const errors: LintError[] = [];
-  let currentSlide = 1;
-  let inFrontmatter = false;
-  let inCodeBlock = false;
   const reportedSlides = new Set<number>();
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
-    const lineNumber = i + 1;
-
-    // Track frontmatter
-    if (line.trim() === '---') {
-      if (i === 0) {
-        inFrontmatter = true;
-        continue;
-      } else if (inFrontmatter) {
-        inFrontmatter = false;
-        continue;
-      } else {
-        currentSlide++;
-        continue;
-      }
-    }
-
-    if (inFrontmatter) continue;
-
-    // Track code blocks
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-
-    // Check list item
-    const listMatch = line.match(/^(\s*)([-*+]|\d+\.)\s/);
-    if (listMatch) {
-      const indent = listMatch[1]?.length ?? 0;
-      // Assume 2 spaces or 1 tab per level
-      const depth = Math.floor(indent / 2) + 1;
-
-      if (depth > mergedConfig.maxDepth && !reportedSlides.has(currentSlide)) {
-        reportedSlides.add(currentSlide);
+  visitSlides(content, {
+    onListItem(_text: string, depth: number, _ordered: boolean, context: LineContext) {
+      if (depth > mergedConfig.maxDepth && !reportedSlides.has(context.slideNumber)) {
+        reportedSlides.add(context.slideNumber);
         errors.push({
           ruleId: 'marp/max-nested-list',
-          slideNumber: currentSlide,
-          lineNumber,
-          message: `Slide ${currentSlide}: List nesting depth is ${depth} (max: ${mergedConfig.maxDepth}). Deep nesting reduces readability.`,
+          slideNumber: context.slideNumber,
+          lineNumber: context.lineNumber,
+          message: `Slide ${context.slideNumber}: List nesting depth is ${depth} (max: ${mergedConfig.maxDepth}). Deep nesting reduces readability.`,
           severity: 'warning'
         });
       }
     }
-  }
+  });
 
   return errors;
 }

--- a/src/rules/slide-title-required.ts
+++ b/src/rules/slide-title-required.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LintError } from './slide-line-count.js';
+import { visitSlides, type LineContext } from '../utils/slide-visitor.js';
 
 export interface SlideTitleRequiredConfig {
   enabled?: boolean;
@@ -27,77 +28,37 @@ export function slideTitleRequired(
     return [];
   }
 
-  const lines = content.split('\n');
   const errors: LintError[] = [];
-  let currentSlide = 1;
-  let slideStartLine = 1;
-  let inFrontmatter = false;
-  let inCodeBlock = false;
   let hasTitle = false;
+  let slideStartLine = 1;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
-    const lineNumber = i + 1;
+  visitSlides(content, {
+    onSlideStart(slideNumber: number, startLine: number) {
+      hasTitle = false;
+      slideStartLine = startLine;
+    },
 
-    // Track frontmatter
-    if (line.trim() === '---') {
-      if (i === 0) {
-        inFrontmatter = true;
-        continue;
-      } else if (inFrontmatter) {
-        inFrontmatter = false;
-        continue;
-      } else {
-        // End of slide - check if it had a title
-        if (!hasTitle && !mergedConfig.skipSlides.includes(currentSlide)) {
-          // Skip first slide (usually has frontmatter + title)
-          if (currentSlide > 1) {
-            errors.push({
-              ruleId: 'marp/slide-title-required',
-              slideNumber: currentSlide,
-              lineNumber: slideStartLine,
-              message: `Slide ${currentSlide}: No title heading found. Add a heading (H${mergedConfig.allowedLevels.join('/H')}).`,
-              severity: 'warning'
-            });
-          }
+    onSlideEnd(slideNumber: number) {
+      if (!hasTitle && !mergedConfig.skipSlides.includes(slideNumber)) {
+        // Skip first slide (usually has frontmatter + title)
+        if (slideNumber > 1) {
+          errors.push({
+            ruleId: 'marp/slide-title-required',
+            slideNumber,
+            lineNumber: slideStartLine,
+            message: `Slide ${slideNumber}: No title heading found. Add a heading (H${mergedConfig.allowedLevels.join('/H')}).`,
+            severity: 'warning'
+          });
         }
-
-        currentSlide++;
-        slideStartLine = lineNumber + 1;
-        hasTitle = false;
-        continue;
       }
-    }
+    },
 
-    if (inFrontmatter) continue;
-
-    // Track code blocks
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-
-    // Check for headings
-    const headingMatch = line.match(/^(#{1,6})\s+/);
-    if (headingMatch) {
-      const level = headingMatch[1]?.length ?? 0;
+    onHeading(level: number, _text: string, _context: LineContext) {
       if (mergedConfig.allowedLevels.includes(level)) {
         hasTitle = true;
       }
     }
-  }
-
-  // Check last slide
-  if (!hasTitle && !mergedConfig.skipSlides.includes(currentSlide) && currentSlide > 1) {
-    errors.push({
-      ruleId: 'marp/slide-title-required',
-      slideNumber: currentSlide,
-      lineNumber: slideStartLine,
-      message: `Slide ${currentSlide}: No title heading found. Add a heading (H${mergedConfig.allowedLevels.join('/H')}).`,
-      severity: 'warning'
-    });
-  }
+  });
 
   return errors;
 }

--- a/src/rules/table-structure.ts
+++ b/src/rules/table-structure.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LintError } from './slide-line-count.js';
+import { visitSlides, type LineContext } from '../utils/slide-visitor.js';
 
 export interface TableStructureConfig {
   enabled?: boolean;
@@ -39,103 +40,67 @@ export function tableStructure(
     return [];
   }
 
-  const lines = content.split('\n');
   const errors: LintError[] = [];
-  let currentSlide = 1;
-  let inFrontmatter = false;
-  let inCodeBlock = false;
 
-  // Track table parsing
+  // Track table parsing state
   let inTable = false;
   let tableStartLine = 0;
   let tableRows: string[][] = [];
   let hasHeader = false;
   let alignments: string[] = [];
+  let currentTableSlide = 0;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
-    const lineNumber = i + 1;
-
-    // Track frontmatter
-    if (line.trim() === '---') {
-      if (i === 0) {
-        inFrontmatter = true;
-        continue;
-      } else if (inFrontmatter) {
-        inFrontmatter = false;
-        continue;
-      } else {
-        // End table if in one
-        if (inTable) {
-          validateTable({
-            startLine: tableStartLine,
-            rows: tableRows,
-            hasHeader,
-            alignments,
-            slideNumber: currentSlide
-          }, errors, mergedConfig);
-          inTable = false;
-          tableRows = [];
-        }
-        currentSlide++;
-        continue;
-      }
-    }
-
-    if (inFrontmatter) continue;
-
-    // Track code blocks
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-
-    // Check for table row
-    const isTableRow = line.trim().startsWith('|') && line.trim().endsWith('|');
-    const isSeparator = /^\|[\s\-:|]+\|$/.test(line.trim());
-
-    if (isTableRow || isSeparator) {
-      if (!inTable) {
-        inTable = true;
-        tableStartLine = lineNumber;
-        tableRows = [];
-        hasHeader = false;
-        alignments = [];
-      }
-
-      if (isSeparator) {
-        hasHeader = true;
-        // Parse alignments
-        alignments = parseAlignments(line);
-      } else {
-        const cells = parseTableRow(line);
-        tableRows.push(cells);
-      }
-    } else if (inTable) {
-      // End of table
+  const finalizeTable = () => {
+    if (inTable && tableRows.length > 0) {
       validateTable({
         startLine: tableStartLine,
         rows: tableRows,
         hasHeader,
         alignments,
-        slideNumber: currentSlide
+        slideNumber: currentTableSlide
       }, errors, mergedConfig);
-      inTable = false;
-      tableRows = [];
     }
-  }
+    inTable = false;
+    tableRows = [];
+    hasHeader = false;
+    alignments = [];
+  };
+
+  visitSlides(content, {
+    onSlideEnd() {
+      finalizeTable();
+    },
+
+    onLine(line: string, context: LineContext) {
+      const trimmedLine = line.trim();
+      const isTableRow = trimmedLine.startsWith('|') && trimmedLine.endsWith('|');
+      const isSeparator = /^\|[\s\-:|]+\|$/.test(trimmedLine);
+
+      if (isTableRow || isSeparator) {
+        if (!inTable) {
+          inTable = true;
+          tableStartLine = context.lineNumber;
+          tableRows = [];
+          hasHeader = false;
+          alignments = [];
+          currentTableSlide = context.slideNumber;
+        }
+
+        if (isSeparator) {
+          hasHeader = true;
+          alignments = parseAlignments(line);
+        } else {
+          const cells = parseTableRow(line);
+          tableRows.push(cells);
+        }
+      } else if (inTable) {
+        finalizeTable();
+      }
+    }
+  });
 
   // Handle table at end of file
-  if (inTable) {
-    validateTable({
-      startLine: tableStartLine,
-      rows: tableRows,
-      hasHeader,
-      alignments,
-      slideNumber: currentSlide
-    }, errors, mergedConfig);
-  }
+  finalizeTable();
 
   return errors;
 }

--- a/src/utils/slide-visitor.ts
+++ b/src/utils/slide-visitor.ts
@@ -1,0 +1,266 @@
+/**
+ * Slide Visitor Pattern
+ * Eliminates code duplication in static rule parsing loops
+ */
+
+export interface LineContext {
+  /** Current slide number (1-based) */
+  slideNumber: number;
+  /** Current line number (1-based) */
+  lineNumber: number;
+  /** Whether currently inside frontmatter */
+  inFrontmatter: boolean;
+  /** Whether currently inside a code block */
+  inCodeBlock: boolean;
+  /** Language of current code block (if any) */
+  codeBlockLanguage: string;
+  /** Start line of current code block (if any) */
+  codeBlockStartLine: number;
+}
+
+export interface SlideVisitor {
+  /** Called when a slide starts (after frontmatter on first slide) */
+  onSlideStart?(slideNumber: number, startLine: number): void;
+
+  /** Called when a slide ends (on --- or end of file) */
+  onSlideEnd?(slideNumber: number, endLine: number): void;
+
+  /** Called for each line (outside frontmatter and code blocks) */
+  onLine?(line: string, context: LineContext): void;
+
+  /** Called for each line (including inside code blocks, but not frontmatter) */
+  onLineRaw?(line: string, context: LineContext): void;
+
+  /** Called when a heading is found */
+  onHeading?(level: number, text: string, context: LineContext): void;
+
+  /** Called when a code block starts */
+  onCodeBlockStart?(language: string, context: LineContext): void;
+
+  /** Called for each line inside a code block */
+  onCodeBlockLine?(line: string, context: LineContext): void;
+
+  /** Called when a code block ends */
+  onCodeBlockEnd?(lines: string[], language: string, startLine: number, context: LineContext): void;
+
+  /** Called when a list item is found */
+  onListItem?(text: string, depth: number, ordered: boolean, context: LineContext): void;
+
+  /** Called when frontmatter content is found */
+  onFrontmatter?(content: string): void;
+}
+
+/**
+ * Visit slides in markdown content
+ * Handles frontmatter, code blocks, and slide separators
+ */
+export function visitSlides(content: string, visitor: SlideVisitor): void {
+  const lines = content.split('\n');
+
+  let currentSlide = 1;
+  let slideStartLine = 1;
+  let inFrontmatter = false;
+  let frontmatterContent: string[] = [];
+  let inCodeBlock = false;
+  let codeBlockStartLine = 0;
+  let codeBlockLanguage = '';
+  let codeBlockLines: string[] = [];
+  let slideHasStarted = false;
+
+  const getContext = (lineNumber: number): LineContext => ({
+    slideNumber: currentSlide,
+    lineNumber,
+    inFrontmatter,
+    inCodeBlock,
+    codeBlockLanguage,
+    codeBlockStartLine
+  });
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const lineNumber = i + 1;
+
+    // Track frontmatter
+    if (line.trim() === '---') {
+      if (i === 0) {
+        inFrontmatter = true;
+        continue;
+      } else if (inFrontmatter) {
+        inFrontmatter = false;
+        if (visitor.onFrontmatter) {
+          visitor.onFrontmatter(frontmatterContent.join('\n'));
+        }
+        frontmatterContent = [];
+        // Start first slide after frontmatter
+        if (!slideHasStarted && visitor.onSlideStart) {
+          visitor.onSlideStart(currentSlide, lineNumber + 1);
+          slideHasStarted = true;
+        }
+        continue;
+      } else {
+        // Slide break
+        if (visitor.onSlideEnd) {
+          visitor.onSlideEnd(currentSlide, lineNumber - 1);
+        }
+        currentSlide++;
+        slideStartLine = lineNumber + 1;
+
+        if (visitor.onSlideStart) {
+          visitor.onSlideStart(currentSlide, slideStartLine);
+        }
+        continue;
+      }
+    }
+
+    // Collect frontmatter content
+    if (inFrontmatter) {
+      frontmatterContent.push(line);
+      continue;
+    }
+
+    // Start first slide if no frontmatter
+    if (!slideHasStarted) {
+      if (visitor.onSlideStart) {
+        visitor.onSlideStart(currentSlide, 1);
+      }
+      slideHasStarted = true;
+    }
+
+    const context = getContext(lineNumber);
+
+    // Call raw line handler (includes code block content)
+    if (visitor.onLineRaw) {
+      visitor.onLineRaw(line, context);
+    }
+
+    // Track code blocks
+    const codeBlockMatch = line.match(/^(`{3,})(\w*)/);
+    if (codeBlockMatch) {
+      if (!inCodeBlock) {
+        // Start of code block
+        inCodeBlock = true;
+        codeBlockStartLine = lineNumber;
+        codeBlockLanguage = codeBlockMatch[2] ?? '';
+        codeBlockLines = [];
+
+        if (visitor.onCodeBlockStart) {
+          visitor.onCodeBlockStart(codeBlockLanguage, getContext(lineNumber));
+        }
+      } else {
+        // End of code block
+        if (visitor.onCodeBlockEnd) {
+          visitor.onCodeBlockEnd(
+            codeBlockLines,
+            codeBlockLanguage,
+            codeBlockStartLine,
+            getContext(lineNumber)
+          );
+        }
+        inCodeBlock = false;
+        codeBlockLanguage = '';
+        codeBlockLines = [];
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeBlockLines.push(line);
+      if (visitor.onCodeBlockLine) {
+        visitor.onCodeBlockLine(line, getContext(lineNumber));
+      }
+      continue;
+    }
+
+    // Call line handler (outside code blocks)
+    if (visitor.onLine) {
+      visitor.onLine(line, context);
+    }
+
+    // Detect headings
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch && visitor.onHeading) {
+      const level = headingMatch[1]?.length ?? 0;
+      const text = headingMatch[2] ?? '';
+      visitor.onHeading(level, text, context);
+    }
+
+    // Detect list items
+    const listMatch = line.match(/^(\s*)([*\-+]|\d+\.)\s+(.+)$/);
+    if (listMatch && visitor.onListItem) {
+      const indent = listMatch[1]?.length ?? 0;
+      const depth = Math.floor(indent / 2) + 1;
+      const marker = listMatch[2] ?? '';
+      const ordered = /^\d+\./.test(marker);
+      const text = listMatch[3] ?? '';
+      visitor.onListItem(text, depth, ordered, context);
+    }
+  }
+
+  // Handle last slide
+  if (slideHasStarted && visitor.onSlideEnd) {
+    visitor.onSlideEnd(currentSlide, lines.length);
+  }
+}
+
+/**
+ * Create a simple visitor that collects all headings
+ */
+export function collectHeadings(content: string): Array<{
+  level: number;
+  text: string;
+  slideNumber: number;
+  lineNumber: number;
+}> {
+  const headings: Array<{
+    level: number;
+    text: string;
+    slideNumber: number;
+    lineNumber: number;
+  }> = [];
+
+  visitSlides(content, {
+    onHeading(level, text, context) {
+      headings.push({
+        level,
+        text,
+        slideNumber: context.slideNumber,
+        lineNumber: context.lineNumber
+      });
+    }
+  });
+
+  return headings;
+}
+
+/**
+ * Create a simple visitor that collects all code blocks
+ */
+export function collectCodeBlocks(content: string): Array<{
+  language: string;
+  lines: string[];
+  startLine: number;
+  endLine: number;
+  slideNumber: number;
+}> {
+  const blocks: Array<{
+    language: string;
+    lines: string[];
+    startLine: number;
+    endLine: number;
+    slideNumber: number;
+  }> = [];
+
+  visitSlides(content, {
+    onCodeBlockEnd(lines, language, startLine, context) {
+      blocks.push({
+        language,
+        lines: [...lines],
+        startLine,
+        endLine: context.lineNumber,
+        slideNumber: context.slideNumber
+      });
+    }
+  });
+
+  return blocks;
+}


### PR DESCRIPTION
## Summary
- `visitSlides()`関数を追加し、frontmatter/codeblock追跡ロジックを一元化
- `SlideVisitor`インターフェースで`onSlideStart`, `onSlideEnd`, `onLine`, `onHeading`, `onCodeBlockEnd`等のイベントハンドラを定義
- 8つの静的ルールをVisitorパターンでリファクタリング
- ヘルパー関数`collectHeadings()`, `collectCodeBlocks()`を追加

## Test plan
- [ ] 型チェックが通ること（`bunx tsc --noEmit`）
- [ ] 実際のMarkdownファイルで各静的ルールが動作すること
- [ ] 既存のAPI互換性が維持されていること

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)