### PR TITLE
chore: 未使用の依存関係を削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "chokidar": "^4.0.0",
     "commander": "^12.1.0",
     "glob": "^11.0.0",
-    "markdownlint": "^0.35.0",
-    "markdownlint-rule-helpers": "^0.26.0",
     "playwright": "^1.48.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- `markdownlint` を削除
- `markdownlint-rule-helpers` を削除

当初 markdownlint の拡張として設計する予定でしたが、独自実装に移行したため不要になったパッケージです。

## Test plan

- [x] `bun install` が成功することを確認
- [ ] `bun run lint` でエラーがないことを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)