### PR TITLE
test: テストカバレッジ拡充

### DIFF
--- a/tests/rules/code-block-length.test.ts
+++ b/tests/rules/code-block-length.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { codeBlockLength } from '../../src/rules/code-block-length.js';
+
+describe('code-block-length', () => {
+  it('should return no errors for short code blocks', () => {
+    const content = `---
+marp: true
+---
+
+\`\`\`javascript
+const x = 1;
+const y = 2;
+\`\`\`
+`;
+    const errors = codeBlockLength(content);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should detect code blocks exceeding max lines', () => {
+    const lines = Array(20).fill('const x = 1;').join('\n');
+    const content = `---
+marp: true
+---
+
+\`\`\`javascript
+${lines}
+\`\`\`
+`;
+    const errors = codeBlockLength(content, { maxLines: 15 });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.ruleId).toBe('marp/code-block-length');
+    expect(errors[0]?.message).toContain('20 lines');
+    expect(errors[0]?.message).toContain('max: 15');
+  });
+
+  it('should detect lines exceeding max length', () => {
+    const longLine = 'x'.repeat(100);
+    const content = `---
+marp: true
+---
+
+\`\`\`javascript
+const short = 1;
+const veryLongVariableName = "${longLine}";
+\`\`\`
+`;
+    const errors = codeBlockLength(content, { maxLineLength: 80 });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.message).toContain('characters');
+    expect(errors[0]?.message).toContain('max: 80');
+  });
+
+  it('should return no errors when rule is disabled', () => {
+    const lines = Array(50).fill('const x = 1;').join('\n');
+    const content = `---
+marp: true
+---
+
+\`\`\`javascript
+${lines}
+\`\`\`
+`;
+    const errors = codeBlockLength(content, { enabled: false });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should respect custom config values', () => {
+    const lines = Array(25).fill('const x = 1;').join('\n');
+    const content = `---
+marp: true
+---
+
+\`\`\`javascript
+${lines}
+\`\`\`
+`;
+    // With maxLines: 30, 25 lines should be OK
+    const errorsWithHighLimit = codeBlockLength(content, { maxLines: 30 });
+    expect(errorsWithHighLimit).toHaveLength(0);
+
+    // With maxLines: 20, 25 lines should trigger error
+    const errorsWithLowLimit = codeBlockLength(content, { maxLines: 20 });
+    expect(errorsWithLowLimit.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/rules/html-blank-lines.test.ts
+++ b/tests/rules/html-blank-lines.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { htmlBlankLines } from '../../src/rules/html-blank-lines.js';
+
+describe('html-blank-lines', () => {
+  it('should return no errors when blank lines are present', () => {
+    const content = `---
+marp: true
+---
+
+<div class="container">
+
+- List item 1
+- List item 2
+
+</div>
+`;
+    const errors = htmlBlankLines(content);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should detect missing blank line after HTML tag', () => {
+    const content = `---
+marp: true
+---
+
+<div class="container">
+- List item without blank line
+</div>
+`;
+    const errors = htmlBlankLines(content);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.ruleId).toBe('marp/html-blank-lines');
+    expect(errors[0]?.message).toContain('Missing blank line after HTML tag');
+  });
+
+  it('should detect missing blank line before closing HTML tag', () => {
+    const content = `---
+marp: true
+---
+
+<div>
+
+- List item
+</div>
+`;
+    const errors = htmlBlankLines(content);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.message).toContain('Missing blank line before closing HTML tag');
+  });
+
+  it('should return no errors when rule is disabled', () => {
+    const content = `---
+marp: true
+---
+
+<div>
+- No blank line but rule disabled
+</div>
+`;
+    const errors = htmlBlankLines(content, { enabled: false });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should track slide numbers correctly', () => {
+    const content = `---
+marp: true
+---
+
+# Slide 1
+
+---
+
+<div>
+- Missing blank line on slide 2
+</div>
+`;
+    const errors = htmlBlankLines(content);
+    expect(errors.length).toBeGreaterThan(0);
+    // Frontmatter slide counts as slide 1, so the second --- starts slide 2
+    // but html-blank-lines counts from the initial --- as well
+    expect(errors[0]?.slideNumber).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/rules/max-nested-list.test.ts
+++ b/tests/rules/max-nested-list.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { maxNestedList } from '../../src/rules/max-nested-list.js';
+
+describe('max-nested-list', () => {
+  it('should return no errors for shallow nesting', () => {
+    const content = `---
+marp: true
+---
+
+- Level 1
+  - Level 2
+    - Level 3
+`;
+    const errors = maxNestedList(content);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should detect deeply nested lists', () => {
+    const content = `---
+marp: true
+---
+
+- Level 1
+  - Level 2
+    - Level 3
+      - Level 4 (too deep)
+`;
+    const errors = maxNestedList(content, { maxDepth: 3 });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.ruleId).toBe('marp/max-nested-list');
+    expect(errors[0]?.message).toContain('nesting depth');
+  });
+
+  it('should return no errors when rule is disabled', () => {
+    const content = `---
+marp: true
+---
+
+- Level 1
+  - Level 2
+    - Level 3
+      - Level 4
+        - Level 5
+`;
+    const errors = maxNestedList(content, { enabled: false });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should respect custom maxDepth', () => {
+    const content = `---
+marp: true
+---
+
+- Level 1
+  - Level 2
+`;
+    // With maxDepth: 2, this should be OK
+    const errorsOk = maxNestedList(content, { maxDepth: 2 });
+    expect(errorsOk).toHaveLength(0);
+
+    // With maxDepth: 1, level 2 should trigger error
+    const errorsError = maxNestedList(content, { maxDepth: 1 });
+    expect(errorsError.length).toBeGreaterThan(0);
+  });
+
+  it('should report only once per slide', () => {
+    const content = `---
+marp: true
+---
+
+- Level 1
+  - Level 2
+    - Level 3
+      - Level 4
+        - Level 5
+`;
+    const errors = maxNestedList(content, { maxDepth: 3 });
+    // Should only report once per slide even with multiple deep items
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/tests/rules/slide-content-density.test.ts
+++ b/tests/rules/slide-content-density.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { slideContentDensity } from '../../src/rules/slide-content-density.js';
+
+describe('slide-content-density', () => {
+  it('should return no errors for slides with low density', () => {
+    const content = `---
+marp: true
+---
+
+# Simple Slide
+
+- Item 1
+- Item 2
+`;
+    const errors = slideContentDensity(content);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should detect slides with too many characters', () => {
+    const longText = 'x'.repeat(1000);
+    const content = `---
+marp: true
+---
+
+# Slide 1
+
+---
+
+# Dense Slide
+
+${longText}
+`;
+    const errors = slideContentDensity(content, { maxCharacters: 800 });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.ruleId).toBe('marp/slide-content-density');
+    expect(errors[0]?.message).toContain('characters');
+  });
+
+  it('should detect slides with too many list items', () => {
+    const items = Array(20).fill('- List item').join('\n');
+    const content = `---
+marp: true
+---
+
+# Slide 1
+
+---
+
+# Many Items
+
+${items}
+`;
+    const errors = slideContentDensity(content, { maxListItems: 15 });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.message).toContain('list items');
+  });
+
+  it('should return no errors when rule is disabled', () => {
+    const longText = 'x'.repeat(2000);
+    const content = `---
+marp: true
+---
+
+${longText}
+`;
+    const errors = slideContentDensity(content, { enabled: false });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should skip frontmatter slide', () => {
+    const longText = 'x'.repeat(1000);
+    const content = `---
+marp: true
+theme: default
+class: lead
+${longText}
+---
+
+# Normal slide
+`;
+    // First slide with frontmatter should be skipped
+    const errors = slideContentDensity(content, { maxCharacters: 100 });
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/tests/utils/config.test.ts
+++ b/tests/utils/config.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { isRuleEnabled, loadConfig } from '../../src/utils/config.js';
+
+describe('config', () => {
+  describe('loadConfig', () => {
+    it('should return default config when no config file exists', () => {
+      // Use a path where no config file exists
+      const config = loadConfig('/tmp/nonexistent');
+      expect(config).toBeDefined();
+      expect(config.rules).toBeDefined();
+      expect(config.viewport).toBeDefined();
+    });
+
+    it('should have default values for rules', () => {
+      const config = loadConfig('/tmp/nonexistent');
+      expect(config.rules['marp/slide-line-count']).toBeDefined();
+      expect(config.rules['marp/overflow']).toBeDefined();
+    });
+
+    it('should have default viewport dimensions', () => {
+      const config = loadConfig('/tmp/nonexistent');
+      expect(config.viewport?.width).toBe(1280);
+      expect(config.viewport?.height).toBe(720);
+    });
+  });
+
+  describe('isRuleEnabled', () => {
+    it('should return true for enabled rules', () => {
+      const config = loadConfig('/tmp/nonexistent');
+      expect(isRuleEnabled(config, 'marp/slide-line-count')).toBe(true);
+    });
+
+    it('should return false for explicitly disabled rules', () => {
+      const config = {
+        rules: {
+          'marp/slide-line-count': { enabled: false }
+        },
+        viewport: { width: 1280, height: 720 }
+      };
+      expect(isRuleEnabled(config, 'marp/slide-line-count')).toBe(false);
+    });
+
+    it('should handle boolean rule config', () => {
+      const config = {
+        rules: {
+          'marp/html-blank-lines': false
+        },
+        viewport: { width: 1280, height: 720 }
+      };
+      expect(isRuleEnabled(config, 'marp/html-blank-lines')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
静的ルールとユーティリティのテストを追加し、テストカバレッジを拡充。

## New Test Files
| File | Tests | Coverage |
|------|-------|----------|
| `html-blank-lines.test.ts` | 5 | HTML空行ルール |
| `code-block-length.test.ts` | 5 | コードブロック長ルール |
| `max-nested-list.test.ts` | 5 | ネスト深度ルール |
| `slide-content-density.test.ts` | 5 | コンテンツ密度ルール |
| `config.test.ts` | 6 | 設定管理 |

## Test Count
- Before: 20 tests
- After: 46 tests (+26)

## Test plan
- [x] All 46 tests pass
- [x] TypeScript typecheck passes
- [x] Biome check passes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)