### PR TITLE
ci: GitHub Actions CI/CDパイプラインの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run check
+
+      - name: Test
+        run: bun run test run
+
+      - name: Build
+        run: bun run build
+
+  build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Check CLI works
+        run: |
+          echo '---
+          marp: true
+          ---
+          # Test Slide
+          ' > /tmp/test.md
+          node dist/index.js --static /tmp/test.md


### PR DESCRIPTION
## Summary
- Node.js 18, 20, 22でのマトリックステスト
- typecheck, lint, test, buildの自動実行
- PRおよびmainブランチへのpushで実行
- CLIの動作確認ジョブを追加

## Test plan
- [x] ワークフロー構文の確認
- [ ] GitHub Actionsで実行確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)