### PR TITLE
ci: コードカバレッジレポートの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,29 @@ jobs:
       - name: Build
         run: bun run build
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests with coverage
+        run: bun run test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+          verbose: true
+
   build-check:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # marplint
 
+[![CI](https://github.com/cuzic/marplint/actions/workflows/ci.yml/badge.svg)](https://github.com/cuzic/marplint/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/cuzic/marplint/graph/badge.svg)](https://codecov.io/gh/cuzic/marplint)
+
 Marpスライド用の高機能linter。オーバーフロー、余白、アクセシビリティなど様々な問題を検出・修正します。
 
 ## 機能一覧

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:fix": "biome check ./src ./tests --write",
     "format": "biome format ./src ./tests --write",
     "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "validate": "bun run typecheck && bun run check && bun run test run"
   },
   "dependencies": {
@@ -33,6 +34,7 @@
     "@biomejs/biome": "^2.3.10",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^4.0.16",
     "tsup": "^8.3.0",
     "typescript": "^5.6.0",
     "vitest": "^4.0.16"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,12 @@ export default defineConfig({
     include: ['tests/**/*.test.ts'],
     environment: 'node',
     globals: true,
-  },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts', 'src/types/**']
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- Vitest v8 coverageプロバイダーを設定
- CI/CDワークフローにcoverageジョブを追加（Codecov連携）
- READMEにCI/coverageバッジを追加

Closes #25

## Test plan
- [ ] CI/CDが正常に実行される
- [ ] coverageジョブがカバレッジを収集する
- [ ] Codecovにレポートがアップロードされる
- [ ] バッジが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)